### PR TITLE
Enable anonymous IAM requests for testing

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -900,15 +900,16 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
                                  urllib.parse.urlencode(req.params))
 
 
-class STSAnonHandler(AuthHandler):
+class QueryAnonHandler(AuthHandler):
     """
     Provides pure query construction (no actual signing).
 
-    Used for making anonymous STS request for operations like
-    ``assume_role_with_web_identity``.
+    Used for making anonymous STS requests for operations like
+    ``assume_role_with_web_identity`` and anonymous IAM requests
+    for testing.
     """
 
-    capability = ['sts-anon']
+    capability = ['query-anon']
 
     def _escape_value(self, value):
         # This is changed from a previous version because this string is

--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -61,8 +61,14 @@ class IAMConnection(AWSQueryConnection):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  is_secure=True, port=None, proxy=None, proxy_port=None,
                  proxy_user=None, proxy_pass=None, host='iam.amazonaws.com',
-                 debug=0, https_connection_factory=None, path='/',
+                 debug=0, https_connection_factory=None, path='/', anon=False,
                  security_token=None, validate_certs=True, profile_name=None):
+        """
+        :type anon: boolean
+        :param anon: If this parameter is True, the ``IAMConnection`` object
+            will make anonymous requests.
+        """
+        self.anon = anon
         super(IAMConnection, self).__init__(aws_access_key_id,
                                             aws_secret_access_key,
                                             is_secure, port, proxy,
@@ -73,7 +79,10 @@ class IAMConnection(AWSQueryConnection):
                                             profile_name=profile_name)
 
     def _required_auth_capability(self):
-        return ['hmac-v4']
+        if self.anon:
+            return ['query-anon']
+        else:
+            return ['hmac-v4']
 
     def get_response(self, action, params, path='/', parent=None,
                      verb='POST', list_marker='Set'):

--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -108,7 +108,7 @@ class STSConnection(AWSQueryConnection):
 
     def _required_auth_capability(self):
         if self.anon:
-            return ['sts-anon']
+            return ['query-anon']
         else:
             return ['hmac-v4']
 


### PR DESCRIPTION
Currently the -N (anon) parameter passed by toms3 is ignored by the IAM
connection, which is preventing me from performing negative testing.

We can't use the 'anon' auth handler, as it doesn't build the (unsigned)
query, so rename 'sts-anon' to 'query-anon' and use it for both STS and
IAM (if anon is true).