### PR TITLE
HS-50395: Send sts:GetCallerIdentity requests as POSTs

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -932,11 +932,18 @@ class QueryAnonHandler(AuthHandler):
         qs = self._build_query_string(
             http_request.params
         )
-        boto.log.debug('query_string in body: %s' % qs)
-        headers['Content-Type'] = 'application/x-www-form-urlencoded'
-        # This will be  a POST so the query string should go into the body
-        # as opposed to being in the uri
-        http_request.body = qs
+        if http_request.method == 'POST':
+            boto.log.debug('query_string in body: %s' % qs)
+            headers['Content-Type'] = 'application/x-www-form-urlencoded'
+            # This is a POST so the query string should go into the body
+            # as opposed to being in the uri
+            http_request.body = qs
+        else:
+            # This is a GET so the query string should go into the URI
+            http_request.body = ''
+            http_request.path = http_request.path.split('?')[0]
+            http_request.path = http_request.path + '?' + qs
+            boto.log.debug('URI with query_string: %s' % http_request.path)
 
 
 class QuerySignatureHelper(HmacKeys):

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -941,6 +941,8 @@ class QueryAnonHandler(AuthHandler):
         else:
             # This is a GET so the query string should go into the URI
             http_request.body = ''
+            # If this is a retried req, the qs from the previous try will
+            # already be there. We need to get rid of that and rebuild it.
             http_request.path = http_request.path.split('?')[0]
             http_request.path = http_request.path + '?' + qs
             boto.log.debug('URI with query_string: %s' % http_request.path)


### PR DESCRIPTION
The AWS API examples show GetCallerIdentity as a POST, whereas boto currently sends it as a GET.

That worked fine until I tested with anonymous requests. Boto's query-anon AuthHandler assumes that all requests will be POSTs, and so always writes the query params into the request body. This causes anonymous GetCallerIdentity requests to be sent as GETs with the query params in the request body. The IAM handler assumes query params for GETs are always in the URI, so it fails to read the request correctly.

I didn't notice until I tried to return STS errors for STS requests and found that the IAM handler wasn't able to determine which action was being performed.

This commit includes two changes - (1) send GetCallerIdentity requests as POSTs, and (2) update the query-anon AuthHandler to send query params in the URI for GET requests. The second change isn't strictly needed to work around the problem I'm seeing, but it'll ensure any GET requests that are added in the future behave as expected.