### PR TITLE
HS-50398 Fix typo in TransitiveTagKeys.member.N parameter

### DIFF
--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -436,7 +436,7 @@ class STSConnection(AWSQueryConnection):
         if transitive_tag_keys:
             idx = 1
             for ttk in transitive_tag_keys:
-                params['TransitiveTagKey.member.%d' % idx] = ttk
+                params['TransitiveTagKeys.member.%d' % idx] = ttk
                 idx += 1
         return self.get_object('AssumeRole', params, AssumedRole, verb='POST')
 


### PR DESCRIPTION
When using toms3's `sts.py` with the `-T` argument, boto sends an sts:AssumeRole request with param TransitiveTagKey.member.N, but in the AWS docs its TransitiveTagKey**s**.member.N.  This commit fixes the typo.

I'm using it to test HS-50398.