### PR TITLE
Fix 'port' type from str to integer in redirecting request

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1037,6 +1037,7 @@ class AWSAuthConnection(object):
                     # that's the case we need to split them up properly
                     if ':' in request.host:
                         request.host, request.port = request.host.split(':', 1)
+                        request.port = int(request.port)
                     msg = 'Redirecting: %s' % scheme + '://'
                     msg += request.host + request.path
                     boto.log.debug(msg)


### PR DESCRIPTION
If you are in the following conditions, some S3 operations(like GET Service) that could be redirected to S3 server in other regions may fail as 'port' type is incorrectly set to string which should be integer when making an S3 connection.

- using "IP" format entries in "config" file
- HyperStore is deployed in a multi-region
- buckets are located across regions

**"config" file under toms3**
```
cloudian IP 172.28.0.2 172.28.0.3 172.28.0.4 172.28.0.5 172.28.0.6 172.28.0.7 172.28.0.8 172.28.0.9
cloudian 00dfe4cf36521f25b723 cr9b3v7OK7camdzzlJwclpTbhoZTal0uVQN1CbOu r1bn
cloudian s3-region1.cloudian.com 80:443
```

```
# ./bucket.py
Using 'cloudian' user '0'

Using IP: 172.28.0.6
Owner: 30182390bc9cc1607155d95b1ee67e0c
Using IP: 172.28.0.6
Using IP: 172.28.0.2
Traceback (most recent call last):
  File "./bucket.py", line 262, in <module>
    sdict = b.get_versioning_status()
  File "/root/work/boto/boto/s3/bucket.py", line 1562, in get_versioning_status
    query_args='versioning', headers=headers)
  File "/root/work/boto/boto/s3/connection.py", line 683, in make_request
    retry_handler=retry_handler
  File "/root/work/boto/boto/connection.py", line 1128, in make_request
    retry_handler=retry_handler)
  File "/root/work/boto/boto/connection.py", line 961, in _mexe
    request.body, request.headers)
  File "/usr/local/lib/python2.7/httplib.py", line 995, in request
    self._send_request(method, url, body, headers)
  File "/usr/local/lib/python2.7/httplib.py", line 1029, in _send_request
    self.endheaders(body)
  File "/usr/local/lib/python2.7/httplib.py", line 991, in endheaders
    self._send_output(message_body)
  File "/usr/local/lib/python2.7/httplib.py", line 844, in _send_output
    self.send(msg)
  File "/usr/local/lib/python2.7/httplib.py", line 806, in send
    self.connect()
  File "/usr/local/lib/python2.7/httplib.py", line 787, in connect
    self.timeout, self.source_address)
  File "/usr/local/lib/python2.7/socket.py", line 562, in create_connection
    sock.connect(sa)
  File "/usr/local/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
#
```
**excerpt from boto.log**
```
GET


Wed, 28 Apr 2021 05:11:07 GMT
/r1bn/?versioning
2021-04-28 14:11:07,219 boto [DEBUG]:Signature:
AWS 00dfe4cf36521f25b723:qqZs63nwJ4//9rFeKuhe9mpngVs=
2021-04-28 14:11:07,219 boto [DEBUG]:Final headers: {'Date': 'Wed, 28 Apr 2021 05:11:07 GMT', 'Content-Length': '0', 'Authorization': u'AWS 00dfe4cf36521f25b723:qqZs63nwJ4//9rFeKuhe9mpngVs=', 'User-Agent': 'Boto/2.42.0 Python/2.7.8 Linux/3.10.0-862.14.4.el7.x86_64'}
2021-04-28 14:11:07,222 boto [DEBUG]:Response headers: [('content-length', '390'), ('x-gmt-message', 'You are being redirected to the bucket while DNS updates.'), ('server', 'CloudianS3'), ('x-amz-request-id', 'df7d2da1-776d-144c-83ed-0242ac1c0006'), ('x-gmt-error-code', 'TemporaryRedirect'), ('location', 'http://r1bn.s3-region1.cloudian.com:80/?versioning'), ('date', 'Wed, 28 Apr 2021 05:11:07 GMT'), ('content-type', 'application/xml')]
2021-04-28 14:11:07,222 boto [DEBUG]:BEFORE request.host: r1bn.s3-region1.cloudian.com:80
2021-04-28 14:11:07,222 boto [DEBUG]:AFTER request.host: r1bn.s3-region1.cloudian.com
2021-04-28 14:11:07,222 boto [DEBUG]:Redirecting: http://r1bn.s3-region1.cloudian.com/?versioning
2021-04-28 14:11:07,222 boto [DEBUG]:OZAINT request.port: 80, <type 'str'>
2021-04-28 14:11:07,223 boto [DEBUG]:establishing HTTP connection: kwargs={'port': '80', 'timeout': 70}
2021-04-28 14:11:07,223 boto [DEBUG]:Token: None
2021-04-28 14:11:07,223 boto [DEBUG]:StringToSign:
GET


Wed, 28 Apr 2021 05:11:07 GMT
/r1bn/?versioning
2021-04-28 14:11:07,223 boto [DEBUG]:Signature:
AWS 00dfe4cf36521f25b723:qqZs63nwJ4//9rFeKuhe9mpngVs=
2021-04-28 14:11:07,223 boto [DEBUG]:Final headers: {'Date': 'Wed, 28 Apr 2021 05:11:07 GMT', 'Content-Length': '0', 'Authorization': u'AWS 00dfe4cf36521f25b723:qqZs63nwJ4//9rFeKuhe9mpngVs=', 'User-Agent': 'Boto/2.42.0 Python/2.7.8 Linux/3.10.0-862.14.4.el7.x86_64'}
```

Note that 
**[DEBUG]:establishing HTTP connection: kwargs={'port': '80', 'timeout': 70}**
should be like
**[DEBUG]:establishing HTTP connection: kwargs={'port': 80, 'timeout': 70}**

**After the fix**
```
# ./bucket.py
Using 'cloudian' user '0'

Using IP: 172.28.0.2
Owner: 30182390bc9cc1607155d95b1ee67e0c
Using IP: 172.28.0.3
r1bn 2021-04-28T04:52:47.238Z DEFAULT Off
Using IP: 172.28.0.3
Using IP: 172.28.0.2
Using IP: 172.28.0.2
Using IP: 172.28.0.9
Using IP: 172.28.0.4
Using IP: 172.28.0.6
r2bn 2021-04-28T04:52:53.125Z region2 Off
#
```