### PR TITLE
Don't use [] as default parameter in __init__.

### DIFF
--- a/boto/s3/lifecycle.py
+++ b/boto/s3/lifecycle.py
@@ -98,9 +98,9 @@ class FilterSet(object):
     </LifecycleConfiguration>
     """
 
-    def __init__(self, prefix='', tag_list=[]):
+    def __init__(self, prefix='', tag_list=None):
         self.prefix = prefix
-        self.tag_list = tag_list
+        self.tag_list = tag_list or []
 
     def startElement(self, name, attrs, connection):
         if name == 'Tag':


### PR DESCRIPTION
Don't use [] as default parameter in __init__ to avoid the following issues.

https://stackoverflow.com/questions/19497879/using-a-empty-list-as-default-parameter-in-init-why-the-list-in-all-instanc
https://bytes.com/topic/python/answers/25267-empty-list-default-parameter