### PR TITLE
Return Response Info instead of raising an Exception in get_list func

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -1233,7 +1233,7 @@ class AWSQueryConnection(AWSAuthConnection):
         else:
             boto.log.error('%s %s' % (response.status, response.reason))
             boto.log.error('%s' % body)
-            raise self.ResponseError(response.status, response.reason, body)
+            return self.ResponseError(response.status, response.reason, body)
 
     def get_object(self, action, params, cls, path='/',
                    parent=None, verb='GET'):


### PR DESCRIPTION
This is the change request from Sherry which is to return Response Info instead of raising an Exception in get_list func.
She wants to check error code/message for SQS get_message request.
