### PR TITLE
fix sigv4 error in python3.[1-7]

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -40,7 +40,7 @@ import os
 import posixpath
 import re
 
-from boto.compat import urllib, encodebytes, parse_qs_safe, json
+from boto.compat import urllib, encodebytes, parse_qs_safe, json, six
 from boto.auth_handler import AuthHandler
 from boto.exception import BotoClientError
 
@@ -591,10 +591,10 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # Urlencode the path, **NOT** ``auth_path`` (because vhosting).
         path = urllib.parse.urlparse(http_request.path)
         # Because some quoting may have already been applied, let's back it out.
-        if isinstance(path.path, bytes):
-            unquoted = urllib.parse.unquote(path.path)
-        else:
+        if six.PY2 and not isinstance(path.path, bytes):
             unquoted = urllib.parse.unquote(path.path.encode('utf-8'))
+        else:
+            unquoted = urllib.parse.unquote(path.path)
         # Requote, this time addressing all characters.
         encoded = urllib.parse.quote(unquoted, '/~')
         return encoded


### PR DESCRIPTION
PROBLEM:

Using python 3.[1-7], sigv4 fails.

> ./get.py -4 a
> File "./get.py", line 350, in <module>
>     hkey = bucket.get_key(key_name=key_name, headers=headers, version_id=ver, partnum=partnum, response_headers=res_hdrs)
>   File "/root/work/boto/boto/s3/bucket.py", line 217, in get_key
>     key, resp = self._get_key_internal(key_name, headers, query_args_l)
>   File "/root/work/boto/boto/s3/bucket.py", line 224, in _get_key_internal
>     query_args=query_args)
>   File "/root/work/boto/boto/s3/connection.py", line 683, in make_request
>     retry_handler=retry_handler
>   File "/root/work/boto/boto/connection.py", line 1121, in make_request
>     retry_handler=retry_handler)
>   File "/root/work/boto/boto/connection.py", line 947, in _mexe
>     request.authorize(connection=self)
>   File "/root/work/boto/boto/connection.py", line 393, in authorize
>     connection._auth_handler.add_auth(self, **kwargs)
> 
> 
>   File "/root/work/boto/boto/auth.py", line 779, in add_auth
>     **kwargs)
>   File "/root/work/boto/boto/auth.py", line 558, in add_auth
>     canonical_request = self.canonical_request(req)
>   File "/root/work/boto/boto/auth.py", line 428, in canonical_request
>     cr.append(self.canonical_uri(http_request))
>   File "/root/work/boto/boto/auth.py", line 597, in canonical_uri
>     unquoted = urllib.parse.unquote(path.path.encode('utf-8'))
>   File "/usr/lib64/python3.6/urllib/parse.py", line 630, in unquote
>     if '%' not in string:
> TypeError: a bytes-like object is required, not 'str'
> 

FIX:

For python2.7, if "path" is in unicode type, need to encode it to str.
For python3, don't encode them since encoding a string returns bytes and won't work for python 3.[1-7].

python 2.7      rllib.parse.unquote() takes in string(bytes) only
python 3.[1-7]  rllib.parse.unquote() takes in string only
python 3.8 >    rllib.parse.unquote() takes in string or bytes objects

Ref: 
Change in python 3.8 https://github.com/python/cpython/commit/aad2ee01561f260c69af1951c0d6fcaf75c4d41b


VERIFICATION:

> Tested python 2.7 
> 
>  python2 mpu.py -u MjQ3MzhkNTMzMzE2NTQ4NDQ3OTAzNTA -p 1 -k 3 -b 1  -S cumulus --ssl --4=0  あ
>  python2 mpu.py -u MjQ3MzhkNTMzMzE2NTQ4NDQ3OTAzNTA -c   あ
>  python2 mpu.py -u MjQ3MzhkNTMzMzE2NTQ4NDQ3OTAzNTA -c   あ
> 

> Tested python 3.7
> 
>  ./mpu.py --4=0 --ssl  -i あ
> Using 'cloudian' bucket 'sh119' and user '0'
> 
> MPU Initiated あ (MDA5YTAyMjAxNjU0ODQ3MjYyNzg2)
> 
>  ./mpu.py -u MDA5YTAyMjAxNjU0ODQ3MjYyNzg2  -p 1 -k 3 -b 1 --ssl --4=0  あ
> Using 'cloudian' bucket 'sh119' and user '0'
> あ MDA5YTAyMjAxNjU0ODQ3MjYyNzg2 part 1
> あ MDA5YTAyMjAxNjU0ODQ3MjYyNzg2 part 2
> あ MDA5YTAyMjAxNjU0ODQ3MjYyNzg2 part 3
> 
>  ./mpu.py -u MDA5YTAyMjAxNjU0ODQ3MjYyNzg2 -c --ssl --4=0  あ
> Using 'cloudian' bucket 'sh119' and user '0'
> 

> Tested python 3.10
> 
>  ./mpu.py --4=0 --ssl  -i あ
> Using 'cloudian' bucket 'sh119' and user '0'
> 
> MPU Initiated あ (MDBjMDAyMTYxNjU0ODQ3Mzc0NDIz)
> 
>  ./mpu.py -u MDBjMDAyMTYxNjU0ODQ3Mzc0NDIz -p 1 -k 3 -b 1 --ssl --4=0  あ
> Using 'cloudian' bucket 'sh119' and user '0'
> 
> あ MDBjMDAyMTYxNjU0ODQ3Mzc0NDIz part 1
> あ MDBjMDAyMTYxNjU0ODQ3Mzc0NDIz part 2
> あ MDBjMDAyMTYxNjU0ODQ3Mzc0NDIz part 3
> 
> ./mpu.py -u MDBjMDAyMTYxNjU0ODQ3Mzc0NDIz  -c --ssl --4=0  あ
> Using 'cloudian' bucket 'sh119' and user '0'