### PR TITLE
Encode string to bytes for BytesIO

### DIFF
--- a/boto/auth.py
+++ b/boto/auth.py
@@ -738,7 +738,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         sts.append(http_request.headers['X-Amz-Date'])
         sts.append(self.credential_scope(http_request))
         sts.append(http_request.sigv4['signature'])
-        sts.append(sha256('').hexdigest())
+        sts.append(sha256(''.encode('utf-8')).hexdigest())
         sts.append(sha256(chunk).hexdigest())
         return '\n'.join(sts)
 

--- a/boto/auth.py
+++ b/boto/auth.py
@@ -166,10 +166,10 @@ class HmacAuthV1Handler(AuthHandler, HmacKeys):
         headers['Authorization'] = auth
 
     def sign_post_policy(self, host, post_policy, fields):
-        b64Policy = base64.b64encode(post_policy)
+        b64Policy = base64.b64encode(post_policy.encode('utf-8'))
         fields['AWSAccessKeyId'] = self._provider.access_key
-        fields['policy'] = b64Policy
-        fields['signature'] = self.sign_string(b64Policy)
+        fields['policy'] = b64Policy.decode('utf-8')
+        fields['signature'] = self.sign_string(b64Policy.decode('utf-8'))
 
 class HmacAuthV2Handler(AuthHandler, HmacKeys):
     """
@@ -804,7 +804,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         # Finalize the policy
         jpolicy = json.dumps(policy)
         boto.log.debug('Final post policy: %s' % jpolicy)
-        b64Policy = base64.b64encode(jpolicy)
+        b64Policy = base64.b64encode(jpolicy.encode('utf-8')).decode('utf-8')
         fields['policy'] = b64Policy
 
         # Finally calculate the signature
@@ -822,11 +822,11 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         for cond in o_conds:
             try:
                 # cond is a dictionary
-                if cond.has_key('x-amz-algorithm'):
+                if 'x-amz-algorithm' in cond:
                     continue
-                elif cond.has_key('x-amz-credential'):
+                elif 'x-amz-credential' in cond:
                     continue
-                elif cond.has_key('x-amz-date'):
+                elif 'x-amz-date' in cond:
                     continue
                 else:
                     n_conds.append(cond)
@@ -844,7 +844,7 @@ class S3HmacAuthV4Handler(HmacAuthV4Handler, AuthHandler):
         for name in ('AWSAccessKeyId', 'signature', 'policy',
                      'x-amz-date', 'x-amz-algorithm', 'x-amz-credential',
                      'x-amz-signature', ):
-            if fields.has_key(name):
+            if name in fields:
                 del fields[name]
 
     def presign(self, req, expires, iso_date=None):

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -225,7 +225,7 @@ class Bucket(object):
         response.read()
         # Allow any success status (2xx) - for example this lets us
         # support Range gets, which return status 206:
-        if response.status / 100 == 2:
+        if 200 <= response.status <= 299:
             k = self.key_class(self)
             provider = self.connection.provider
             k.metadata = boto.utils.get_aws_metadata(response.msg, provider)

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -2530,7 +2530,8 @@ class Key(object):
                             headers=headers)
 
     def select_object_content(self, data, headers=None):
-        md5 = compute_md5(BytesIO(data))
+        
+        md5 = compute_md5(BytesIO(data.encode("utf-8")))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'select&select-type=2'
@@ -2561,7 +2562,7 @@ class Key(object):
 
         """
         data = self.RestoreBody % days
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode("utf-8")))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'restore'
@@ -2646,7 +2647,7 @@ class Key(object):
             data = self.RetentionEmptyBody
         else:
             data = self.RetentionBody % (object_lock_mode, object_lock_retain_until_date)
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode("utf-8")))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         if bypass_governance_retention is not None:
@@ -2682,7 +2683,7 @@ class Key(object):
 
     def set_legal_hold(self, object_lock_legal_hold, version_id=None, headers=None):
         data = self.LegalHoldBody % object_lock_legal_hold
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode("utf-8")))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'legal-hold'

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -897,7 +897,7 @@ class Key(object):
                     chunk = fp.read(need)
 
                 # Send the multipart bottom which follows the file data
-                http_conn.send(bottom.encode())
+                http_conn.send(bottom.encode('utf-8'))
 
                 self.size = data_len
 

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1210,17 +1210,17 @@ class Key(object):
                         chunk_hdr = streaming_auth.chunk_header(request, chunk)
                         if chunked_transfer:
                             cte_chunk_len = chunk_len + streaming_auth.chunk_extra_size(chunk_len)
-                            http_conn.send('%x\r\n' % cte_chunk_len)
-                            http_conn.send('%s%s\r\n' % (chunk_hdr, chunk))
-                            http_conn.send('\r\n')
+                            http_conn.send(('%x\r\n' % cte_chunk_len).encode('utf-8'))
+                            http_conn.send(('%s%s\r\n' % (chunk_hdr, chunk.decode('utf-8'))).encode('utf-8'))
+                            http_conn.send('\r\n'.encode('utf-8'))
                         else:
-                            http_conn.send('%s' % chunk_hdr)
+                            http_conn.send(chunk_hdr.encode('utf-8'))
                             http_conn.send(chunk)
-                            http_conn.send('\r\n')
+                            http_conn.send('\r\n'.encode('utf-8'))
                     elif chunked_transfer:
-                        http_conn.send('%x\r\n' % chunk_len)
+                        http_conn.send(('%x\r\n' % chunk_len).encode('utf-8'))
                         http_conn.send(chunk)
-                        http_conn.send('\r\n')
+                        http_conn.send('\r\n'.encode('utf-8'))
                     else:
                         http_conn.send(chunk)
 
@@ -1256,18 +1256,18 @@ class Key(object):
 
                 if streaming_auth is not None:
                     # Need to write the final empty aws-chunk
-                    chunk_hdr = streaming_auth.chunk_header(request, '')
+                    chunk_hdr = streaming_auth.chunk_header(request, ''.encode('utf-8'))
                     if chunked_transfer:
                         cte_chunk_len = streaming_auth.chunk_extra_size(0)
-                        http_conn.send('%x\r\n' % cte_chunk_len)
-                        http_conn.send('%s\r\n' % chunk_hdr)
-                        http_conn.send('\r\n')
+                        http_conn.send(('%x\r\n' % cte_chunk_len).encode('utf-8'))
+                        http_conn.send(('%s\r\n' % chunk_hdr).encode('utf-8'))
+                        http_conn.send('\r\n'.encode('utf-8'))
                     else:
-                        http_conn.send('%s\r\n' % chunk_hdr)
+                        http_conn.send(('%s\r\n' % chunk_hdr).encode())
 
                 if chunked_transfer:
-                    http_conn.send('0\r\n')
-                    http_conn.send('\r\n')
+                    http_conn.send('0\r\n'.encode('utf-8'))
+                    http_conn.send('\r\n'.encode('utf-8'))
 
                 self.size = data_len
 
@@ -1387,7 +1387,7 @@ class Key(object):
                 if streaming == 1:
                     # Stream using Content-Length
                     cl = self.size
-                    full = self.size / BufferSize
+                    full = self.size // BufferSize
                     cl += full * streaming_auth.chunk_extra_size(BufferSize)
                     partial = self.size % BufferSize
                     if partial > 0:

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1995,7 +1995,7 @@ class Key(object):
             fields[provider.server_side_encryption_header] = encrypt_key
             decode_json_data = json.loads(post_policy)
             decode_json_data['conditions'].append(('starts-with', '$%s' % provider.server_side_encryption_header, ''))
-            post_policy = json.dumps(decode_json_data).decode('utf-8')
+            post_policy = json.dumps(decode_json_data).encode('utf-8')
         if reduced_redundancy:
             self.storage_class = 'REDUCED_REDUNDANCY'
             if provider.storage_class_header:

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -845,11 +845,11 @@ class Key(object):
               skips['skip_accept_encoding'] = 1
             http_conn.putrequest(method, path, **skips)
             # It's hard to skip basic authorization, so just delete the headers
-            if headers.has_key('Authorization'):
+            if 'Authorization' in headers:
                 del headers['Authorization']
-            if headers.has_key('x-amz-content-sha256'):
+            if 'x-amz-content-sha256' in headers:
                 del headers['x-amz-content-sha256']
-            if headers.has_key('X-Amz-Date'):
+            if 'X-Amz-Date' in headers:
                 del headers['X-Amz-Date']
             for key in headers:
                 http_conn.putheader(key, headers[key])
@@ -897,7 +897,7 @@ class Key(object):
                     chunk = fp.read(need)
 
                 # Send the multipart bottom which follows the file data
-                http_conn.send(bottom)
+                http_conn.send(bottom.encode())
 
                 self.size = data_len
 
@@ -1000,7 +1000,7 @@ class Key(object):
         conds = policy['conditions']
         for cond in conds:
             try:
-                if cond.has_key(name):
+                if name in cond:
                     # nothing to add
                     return post_policy
             except:
@@ -1017,12 +1017,12 @@ class Key(object):
 
     def form_data(self, fields, boundary):
         # key/file can be overriden in fields for test purposes
-        if fields.has_key('Key'):
+        if 'Key' in fields:
             key = fields['Key']
             del fields['Key']
         else:
             key = self.name
-        if fields.has_key('file'):
+        if 'file' in fields:
             filename = fields['file']
             del fields['file']
         else:
@@ -1995,7 +1995,7 @@ class Key(object):
             fields[provider.server_side_encryption_header] = encrypt_key
             decode_json_data = json.loads(post_policy)
             decode_json_data['conditions'].append(('starts-with', '$%s' % provider.server_side_encryption_header, ''))
-            post_policy = json.dumps(decode_json_data)
+            post_policy = json.dumps(decode_json_data).decode('utf-8')
         if reduced_redundancy:
             self.storage_class = 'REDUCED_REDUNDANCY'
             if provider.storage_class_header:


### PR DESCRIPTION
Some commands were failing due to string passed into BytesIO().
Strings needs to be encoded to bytes.

# ./put.py --retention --gov=1d a
Using 'cloudian' bucket 'r1bn' and user '0'

Putting Object retention for:  a None
Traceback (most recent call last):
  File "./put.py", line 428, in <module>
    bypass_governance_retention=bypass_governance_retention)
  File "/root/work/boto/boto/s3/key.py", line 2649, in set_retention
    md5 = compute_md5(BytesIO(data))
TypeError: a bytes-like object is required, not 'str'
