### PR TITLE
BytesIO needes bytes not str

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -2530,7 +2530,7 @@ class Key(object):
                             headers=headers)
 
     def select_object_content(self, data, headers=None):
-        md5 = compute_md5(BytesIO(data.encode('utf-8')))
+        md5 = compute_md5(BytesIO(data))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'select&select-type=2'

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -2530,7 +2530,7 @@ class Key(object):
                             headers=headers)
 
     def select_object_content(self, data, headers=None):
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode('utf-8')))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'select&select-type=2'
@@ -2561,7 +2561,7 @@ class Key(object):
 
         """
         data = self.RestoreBody % days
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode('utf-8')))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'restore'
@@ -2682,7 +2682,7 @@ class Key(object):
 
     def set_legal_hold(self, object_lock_legal_hold, version_id=None, headers=None):
         data = self.LegalHoldBody % object_lock_legal_hold
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode('utf-8')))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         qargs = 'legal-hold'

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -2646,7 +2646,7 @@ class Key(object):
             data = self.RetentionEmptyBody
         else:
             data = self.RetentionBody % (object_lock_mode, object_lock_retain_until_date)
-        md5 = compute_md5(BytesIO(data))
+        md5 = compute_md5(BytesIO(data.encode('utf-8')))
         headers = headers or {}
         headers['Content-MD5'] = md5[1]
         if bypass_governance_retention is not None:


### PR DESCRIPTION
Some commands were raising error due to BytesIO expecting bytes instead of str.

>   ./put.py --retention --gov=1d a
> Using 'cloudian' bucket 'r1bn' and user '0'
> 
> Putting Object retention for:  a None
> Traceback (most recent call last):
>   File "./put.py", line 428, in <module>
>     bypass_governance_retention=bypass_governance_retention)
>   File "/root/work/boto/boto/s3/key.py", line 2649, in set_retention
>     md5 = compute_md5(BytesIO(data))
> TypeError: a bytes-like object is required, not 'str'
