### PR TITLE
Add ObjectSizeGreaterThan/ObjectSizeLessThan to Lifecycle Rule Filter

### DIFF
--- a/boto/s3/lifecycle.py
+++ b/boto/s3/lifecycle.py
@@ -86,6 +86,23 @@ class FilterSet(object):
         </Rule>
     </LifecycleConfiguration>
 
+    - Specifying a filter based on prefix and object size
+
+    <LifecycleConfiguration>
+        <Rule>
+            <Filter>
+              <And>
+                 <Prefix>key-prefix</Prefix>
+                 <ObjectSizeGreaterThan>long</ObjectSizeGreaterThan>
+                 <ObjectSizeLessThan>long</ObjectSizeLessThan>
+                  ...
+              </And>
+            </Filter>
+            <Status>Enabled</Status>
+            transition/expiration actions.
+        </Rule>
+    </LifecycleConfiguration>
+
     - Specifying an empty filter, in which case the rule applies to all objects in the bucket.
 
     <LifecycleConfiguration>
@@ -98,9 +115,11 @@ class FilterSet(object):
     </LifecycleConfiguration>
     """
 
-    def __init__(self, prefix='', tag_list=None):
+    def __init__(self, prefix='', tag_list=None, size_gt=None, size_lt=None):
         self.prefix = prefix
         self.tag_list = tag_list or []
+        self.size_gt = size_gt
+        self.size_lt = size_lt
 
     def startElement(self, name, attrs, connection):
         if name == 'Tag':
@@ -112,6 +131,10 @@ class FilterSet(object):
     def endElement(self, name, value, connection):
         if name == 'Prefix':
             self.prefix = value
+        elif name == 'ObjectSizeGreaterThan':
+            self.size_gt = value
+        elif name == 'ObjectSizeLessThan':
+            self.size_lt = value
         else:
             setattr(self, name, value)
 
@@ -122,16 +145,33 @@ class FilterSet(object):
     def set_prefix(self, prefix):
         self.prefix = prefix
 
+    def set_size_gt(self, size_gt):
+        self.size_gt = size_gt
+
+    def set_size_lt(self, size_lt):
+        self.size_lt = size_lt
+
     def to_xml(self):
         and_tag = False
-        if (len(self.tag_list) > 1 or
-            (self.prefix != '' and len(self.tag_list) > 0)):
+        filter_count = 0
+        if self.prefix != '':
+            filter_count += 1
+        if self.size_gt:
+            filter_count += 1
+        if self.size_lt:
+            filter_count += 1
+        filter_count += len(self.tag_list)
+        if filter_count > 1:
             and_tag = True
         xml = ''
         if and_tag:
             xml += '<And>'
         if self.prefix != '':
             xml += '<Prefix>%s</Prefix>' % self.prefix
+        if self.size_gt:
+            xml += '<ObjectSizeGreaterThan>%s</ObjectSizeGreaterThan>' % self.size_gt
+        if self.size_lt:
+            xml += '<ObjectSizeLessThan>%s</ObjectSizeLessThan>' % self.size_lt
         for tag in self.tag_list:
             xml += tag.to_xml()
         if and_tag:
@@ -154,7 +194,8 @@ class Rule(object):
                   If True, <Filter> element is used.
 
     :ivar filter_set: An instance of `FilterSet`. This indicates
-         a filter based on both the key prefix and one or more tags.
+         a filter based on the key prefix, object size and one or more
+         tags.
 
     :ivar status: If 'Enabled', the rule is currently being applied.
         If 'Disabled', the rule is not currently being applied.
@@ -532,8 +573,8 @@ class Lifecycle(list):
             be added in lifecycle xml rule.
 
         :type filter_set: FilterSet
-        :iparam filter_set: Indicates a filter based on both the key prefix
-            and one or more tags.
+        :iparam filter_set: Indicates a filter based on the key prefix,
+            object size and one or more tags.
 
         :type status: str
         :param status: If 'Enabled', the rule is currently being applied.

--- a/boto/s3/lifecycle.py
+++ b/boto/s3/lifecycle.py
@@ -116,6 +116,24 @@ class FilterSet(object):
     """
 
     def __init__(self, prefix='', tag_list=None, size_gt=None, size_lt=None):
+        """
+        The Filter is used to identify objects that a Lifecycle Rule applies to.
+
+        :type prefix: string
+        :param prefix: prefix identifying one or more objects to which the rule
+            applies.
+
+        :type tag_list: list
+        :param tag_list: list of Tag() that must exist in the object's tag set
+            in order for the rule to apply.
+
+        :type size_gt: int
+        :param size_gt: Minimum object size to which the rule applies.
+
+        :type size_lt: int
+        :param size_lt: Maximum object size to which the rule applies.
+        """
+
         self.prefix = prefix
         self.tag_list = tag_list or []
         self.size_gt = size_gt
@@ -132,9 +150,9 @@ class FilterSet(object):
         if name == 'Prefix':
             self.prefix = value
         elif name == 'ObjectSizeGreaterThan':
-            self.size_gt = value
+            self.size_gt = int(value)
         elif name == 'ObjectSizeLessThan':
-            self.size_lt = value
+            self.size_lt = int(value)
         else:
             setattr(self, name, value)
 
@@ -156,9 +174,9 @@ class FilterSet(object):
         filter_count = 0
         if self.prefix != '':
             filter_count += 1
-        if self.size_gt:
+        if self.size_gt is not None:
             filter_count += 1
-        if self.size_lt:
+        if self.size_lt is not None:
             filter_count += 1
         filter_count += len(self.tag_list)
         if filter_count > 1:
@@ -168,10 +186,10 @@ class FilterSet(object):
             xml += '<And>'
         if self.prefix != '':
             xml += '<Prefix>%s</Prefix>' % self.prefix
-        if self.size_gt:
-            xml += '<ObjectSizeGreaterThan>%s</ObjectSizeGreaterThan>' % self.size_gt
-        if self.size_lt:
-            xml += '<ObjectSizeLessThan>%s</ObjectSizeLessThan>' % self.size_lt
+        if self.size_gt is not None:
+            xml += '<ObjectSizeGreaterThan>%d</ObjectSizeGreaterThan>' % self.size_gt
+        if self.size_lt is not None:
+            xml += '<ObjectSizeLessThan>%d</ObjectSizeLessThan>' % self.size_lt
         for tag in self.tag_list:
             xml += tag.to_xml()
         if and_tag:


### PR DESCRIPTION
Add **_ObjectSizeGreaterThan_**/**_ObjectSizeLessThan_** to Lifecycle Rule Filter so that toms3/models3 can handle this feature introduced by [HS-56304](https://cloudian.atlassian.net/browse/HS-56304) in 7.5.1.