### PR TITLE
put hangs for 0 byte file

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1180,6 +1180,9 @@ class Key(object):
             need = BufferSize
             if bytes_togo and bytes_togo < BufferSize:
                 need = bytes_togo
+            
+            if bytes_togo == 0:
+                need = 0
             chunk = fp.read(need)
             if streaming_auth is not None:
                 # aws content-length calculations, and minimum chunk size


### PR DESCRIPTION
### [ PROBLEM ]

Model S3 generate mode hangs trying to read from a fp.

> CEXCEPTION: while running generate_model.
Traceback (most recent call last):
  File "//models3/check.py", line 7225, in generate_cmd
    generate_model.main(S3Mod(gen_sizes=sizes), secs=args.seconds,...
>    ...
>
>  File "//boto/boto/s3/key.py", line 1190, in sender
>    more_data = fp.read(required_len)
>  File "/opt/homebrew/Cellar/python@3.10/3.10.6_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/tempfile.py", line 483, in func_wrapper
>    return func(*args, **kwargs)
> KeyboardInterrupt

This can be replicated with toms3 also if we use sigv4

>  ./put.py -b 0 --4=1 obj1 
> Using 'cloudian' bucket 'bk99' and user '0'
> 
>                    <----- HANGS HERE

### [ CAUSE ]

> more_data = fp.read(required_len)

In python3.0, fp.read(required_len) hangs waiting for data if "required_len" is passed as an argument but actual file is 0 byte.
In python2, fp.read(required_len) just returns empty.





