### PR TITLE
python3 conversion

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -382,11 +382,11 @@ class HTTPRequest(object):
              path.find('credential') != -1) and
             path.find('expires=') != -1 and path.find('signature=') != -1):
             # Remove Authorization header when doing query auth
-            if self.headers.has_key('Authorization'):
+            if 'Authorization' in self.headers:
                 del self.headers['Authorization']
-            if self.headers.has_key('x-amz-content-sha256'):
+            if 'x-amz-content-sha256' in self.headers:
                 del self.headers['x-amz-content-sha256']
-            if self.headers.has_key('X-Amz-Date'):
+            if 'X-Amz-Date' in self.headers:
                 del self.headers['X-Amz-Date']
         else:
             # Or just re-Authorize the request


### PR DESCRIPTION
Request from Sherry 
China QA is converting to python3 and experienced the following error.

The change is to use `in` when checking the key in  a dictionary which works for both python3 and python2. 

```
[root@inspour02vm3 cloudianqa]# python3 -W i ./cases/S3/GetObj_BK/test_getFile_BUG30870.py
E
            for key in self.headers:
======================================================================
ERROR: test (__main__.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./cases/S3/GetObj_BK/test_getFile_BUG30870.py", line 62, in test
    Userskey='',query_args=urls[urls.find('?')+1:],NoAuth=True)
  File "/root/cloudianqa/lib/cloudian/RestLib.py", line 825, in send_s3_request
    override_num_retries=override_num_retries, #Max: To fix pipe broken issue;Changed 0 to None so that the default value of 6 can ben used.
  File "/root/boto/boto/s3/connection.py", line 683, in make_request
    retry_handler=retry_handler
  File "/root/boto/boto/connection.py", line 1121, in make_request
    retry_handler=retry_handler)
                 self.protocol, self.host, self.port, self.path, self.params,
  File "/root/boto/boto/connection.py", line 947, in _mexe
    request.authorize(connection=self)
  File "/root/boto/boto/connection.py", line 385, in authorize
    if self.headers.has_key('Authorization'):
AttributeError: 'dict' object has no attribute 'has_key'
```