### PR TITLE
Too strict for checksum_mode on HEAD/GET

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -216,9 +216,8 @@ class Bucket(object):
             query_args_l.append('versionId=%s' % version_id)
         if partnum:
             query_args_l.append('partNumber=%s' % partnum)
-        if checksum_mode is not None and checksum_mode.upper() == 'ENABLED':
+        if checksum_mode is not None:
             headers[provider.checksum_mode_header] = checksum_mode
-
         if response_headers:
             for rk, rv in six.iteritems(response_headers):
                 query_args_l.append('%s=%s' % (rk, urllib.parse.quote(rv)))

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -2229,7 +2229,7 @@ class Key(object):
             query_args.append('versionId=%s' % version_id)
         if partnum:
             query_args.append('partNumber=%s' % partnum)
-        if checksum_mode is not None and checksum_mode.upper() == 'ENABLED':
+        if checksum_mode is not None:
             headers[provider.checksum_mode_header] = checksum_mode
         if response_headers:
             for key in response_headers:


### PR DESCRIPTION
It was too restricted for the **_x-amz-checksum-mode_** value on HEAD/GET Object. The change is more flexible to check/set the header value so that we can test various type of values(case sensitive/insensitive valid value, invalid value etc...)  