### PR TITLE
Fix redirect detection when region requires sigV4

### DIFF
--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1359,7 +1359,7 @@ class Key(object):
             if response.status == 400:
                 body = response.read()
                 if (body is not None and
-                    body.find('AWS4-HMAC-SHA256') != -1):
+                    body.find(b'AWS4-HMAC-SHA256') != -1):
                     boto.log.debug("Reworking request for AWS4-HMAC-SHA256")
                     if spos is not None and spos != fp.tell():
                         fp.seek(spos)


### PR DESCRIPTION
If the original request used sigv2 but the bucket is in a region that requires sigv4, the request will fail with 400 bad request. Boto tries to handle this by looking for the phrase AWS4-HMAC-SHA256 in the error response. This fails with the below exception because the body is of type bytes and find cannot be used with a string parameter. Fix is easy to just use a byte string instead of a str.

  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/s3/key.py", line 1879, in set_contents_from_file
    self.send_file(fp, headers=headers, cb=cb, num_cb=num_cb,
  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/s3/key.py", line 1148, in send_file
    self._send_file_internal(fp, headers=headers, cb=cb, num_cb=num_cb,
  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/s3/key.py", line 1470, in _send_file_internal
    resp = self.bucket.connection.make_request(
  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/s3/connection.py", line 679, in make_request
    return super(S3Connection, self).make_request(
  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/connection.py", line 1120, in make_request
    resp = self._mexe(http_request, sender, override_num_retries,
  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/connection.py", line 973, in _mexe
    status = retry_handler(response, i, next_sleep, request)
  File "/Users/tpodowd/work/toms3/env/lib/python3.10/site-packages/boto/s3/key.py", line 1362, in retry_handler
    body.find('AWS4-HMAC-SHA256') != -1):
TypeError: argument should be integer or bytes-like object, not 'str'