### PR TITLE
use crc32 method in zlib rather than binascii

### DIFF
--- a/boto/s3/checksums.py
+++ b/boto/s3/checksums.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-import binascii
 import base64
 import array
 import hashlib
+import zlib
 
 CRC32C_TABEL = (
     0x00000000, 0xf26b8303, 0xe13b70f7, 0x1350f3f4,
@@ -137,7 +137,7 @@ def cal_checksum(fp=None, size=-1, ctype='crc32', data=None):
         cpos = fp.tell()
         rdata = fp.read(size)
     if ctype == 'crc32':
-        checksum = binascii.crc32(rdata, CRC32_INIT) & _MASK
+        checksum = zlib.crc32(rdata, CRC32_INIT) & _MASK
         checksum = base64.b64encode(checksum.to_bytes(4, 'big')).decode('utf-8')
     elif ctype == 'crc32c':
         checksum = crc32c_cal(rdata)


### PR DESCRIPTION
use crc32 method in zlib lib rather than binascii lib to workaround [the bad crc32 calculation issue](https://bugs.python.org/issue38256)

I believe that it does not happen on Python3.7 and later however there are some testers(QA and me and so on ) who are still using Python3.6 and earlier so decide to use crc32 method from zlib lib rather than letting users upgrade to Python3.7 and later.

```
# python3.6 ./test.py
2575877834
2838121701
2838121701
2838121701
# python3.11 ./test.py
2838121701
2838121701
2838121701
2838121701
#

== test.py ==
import binascii, zlib
bigdata=memoryview(bytearray((1<<32) + 100))

print(binascii.crc32(bigdata))
crc = binascii.crc32(bigdata[:1000])
crc = binascii.crc32(bigdata[1000:], crc)
print(crc)

print(zlib.crc32(bigdata))
crc = zlib.crc32(bigdata[:1000])
crc = zlib.crc32(bigdata[1000:], crc)
print(crc)

```
 
