### PR TITLE
add kmip_profile attr on Key class and handle x-gmt-kmip-profile header

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -256,6 +256,7 @@ class Bucket(object):
             else:
                 k.size = 0
             k.hyperstore = response.getheader('x-gmt-hyperstore')
+            k.kmip_profile = response.getheader('x-gmt-kmip-profile')
             k.name = key_name
             k.handle_version_headers(response)
             k.handle_encryption_headers(response)

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -141,6 +141,7 @@ class Key(object):
         self.filename = None
         self.etag = None
         self.hyperstore = None
+        self.kmip_profile = None
         self.tagging_count = None
         self.mp_parts_count = None
         self.is_latest = False
@@ -432,6 +433,8 @@ class Key(object):
                     self.__dict__[name.lower().replace('-', '_')] = value
                 elif name.lower() == 'x-gmt-hyperstore':
                     self.hyperstore = value
+                elif name.lower() == 'x-gmt-kmip-profile':
+                    self.kmip_profile = value
             self.handle_version_headers(self.resp)
             self.handle_encryption_headers(self.resp)
             self.handle_replication_headers(self.resp)


### PR DESCRIPTION
Due to https://cloudian.atlassian.net/browse/HS-61306 change, added kmip_profile member on Key class and handle x-gmt-kmip-profile header process on HEAD/GET Object call from toms3.
