### PR TITLE
handle response headers on error exception

### DIFF
--- a/boto/exception.py
+++ b/boto/exception.py
@@ -75,11 +75,12 @@ class GSPermissionsError(StoragePermissionsError):
 
 
 class BotoServerError(StandardError):
-    def __init__(self, status, reason, body=None, *args):
-        super(BotoServerError, self).__init__(status, reason, body, *args)
+    def __init__(self, status, reason, body=None, headers=None, *args):
+        super(BotoServerError, self).__init__(status, reason, body, headers, *args)
         self.status = status
         self.reason = reason
         self.body = body or ''
+        self.headers = headers or ''
         self.request_id = None
         self.error_code = None
         self._error_message = None
@@ -151,12 +152,18 @@ class BotoServerError(StandardError):
             super(BotoServerError, self).__setattr__(name, value)
 
     def __repr__(self):
-        return '%s: %s %s\n%s' % (self.__class__.__name__,
-                                  self.status, self.reason, self.body)
+        msg = '%s: %s %s\n%s' % (self.__class__.__name__,
+                                 self.status, self.reason, self.body)
+        if len(self.headers) > 0:
+            msg += '\n%s' % self.headers
+        return msg
 
     def __str__(self):
-        return '%s: %s %s\n%s' % (self.__class__.__name__,
-                                  self.status, self.reason, self.body)
+        msg = '%s: %s %s\n%s' % (self.__class__.__name__,
+                                 self.status, self.reason, self.body)
+        if len(self.headers) > 0:
+            msg += '\n%s' % self.headers
+        return msg
 
     def startElement(self, name, attrs, connection):
         pass
@@ -294,9 +301,9 @@ class StorageResponseError(BotoServerError):
     """
     Error in response from a storage service.
     """
-    def __init__(self, status, reason, body=None):
+    def __init__(self, status, reason, body=None, headers=None):
         self.resource = None
-        super(StorageResponseError, self).__init__(status, reason, body)
+        super(StorageResponseError, self).__init__(status, reason, body, headers)
 
     def startElement(self, name, attrs, connection):
         return super(StorageResponseError, self).startElement(

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -75,12 +75,12 @@ class GSPermissionsError(StoragePermissionsError):
 
 
 class BotoServerError(StandardError):
-    def __init__(self, status, reason, body=None, headers=None, *args):
+    def __init__(self, status, reason, body=None, headers=[], *args):
         super(BotoServerError, self).__init__(status, reason, body, headers, *args)
         self.status = status
         self.reason = reason
         self.body = body or ''
-        self.headers = headers or ''
+        self.headers = headers
         self.request_id = None
         self.error_code = None
         self._error_message = None
@@ -301,7 +301,7 @@ class StorageResponseError(BotoServerError):
     """
     Error in response from a storage service.
     """
-    def __init__(self, status, reason, body=None, headers=None):
+    def __init__(self, status, reason, body=None, headers=[]):
         self.resource = None
         super(StorageResponseError, self).__init__(status, reason, body, headers)
 

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -75,18 +75,20 @@ class GSPermissionsError(StoragePermissionsError):
 
 
 class BotoServerError(StandardError):
-    def __init__(self, status, reason, body=None, headers=[], *args):
-        super(BotoServerError, self).__init__(status, reason, body, headers, *args)
+    def __init__(self, status, reason, body=None, *args):
+        super(BotoServerError, self).__init__(status, reason, body, *args)
         self.status = status
         self.reason = reason
         self.body = body or ''
-        self.headers = headers
         self.request_id = None
         self.error_code = None
         self._error_message = None
         self.message = ''
         self.box_usage = None
-
+        if len(args) > 0:
+            self.headers = args[0]
+        else:
+            self.headers = None
         if isinstance(self.body, bytes):
             try:
                 self.body = self.body.decode('utf-8')
@@ -154,14 +156,14 @@ class BotoServerError(StandardError):
     def __repr__(self):
         msg = '%s: %s %s\n%s' % (self.__class__.__name__,
                                  self.status, self.reason, self.body)
-        if len(self.headers) > 0:
+        if self.headers is not None:
             msg += '\n%s' % self.headers
         return msg
 
     def __str__(self):
         msg = '%s: %s %s\n%s' % (self.__class__.__name__,
                                  self.status, self.reason, self.body)
-        if len(self.headers) > 0:
+        if self.headers is not None:
             msg += '\n%s' % self.headers
         return msg
 
@@ -301,9 +303,9 @@ class StorageResponseError(BotoServerError):
     """
     Error in response from a storage service.
     """
-    def __init__(self, status, reason, body=None, headers=[]):
+    def __init__(self, status, reason, body=None, *args):
         self.resource = None
-        super(StorageResponseError, self).__init__(status, reason, body, headers)
+        super(StorageResponseError, self).__init__(status, reason, body, *args)
 
     def startElement(self, name, attrs, connection):
         return super(StorageResponseError, self).startElement(

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -75,7 +75,7 @@ class GSPermissionsError(StoragePermissionsError):
 
 
 class BotoServerError(StandardError):
-    def __init__(self, status, reason, body=None, *args):
+    def __init__(self, status, reason, body=None, *args, headers=None):
         super(BotoServerError, self).__init__(status, reason, body, *args)
         self.status = status
         self.reason = reason
@@ -85,10 +85,7 @@ class BotoServerError(StandardError):
         self._error_message = None
         self.message = ''
         self.box_usage = None
-        if len(args) > 0:
-            self.headers = args[0]
-        else:
-            self.headers = None
+        self.headers = headers
 
         if isinstance(self.body, bytes):
             try:
@@ -155,18 +152,12 @@ class BotoServerError(StandardError):
             super(BotoServerError, self).__setattr__(name, value)
 
     def __repr__(self):
-        msg = '%s: %s %s\n%s' % (self.__class__.__name__,
-                                 self.status, self.reason, self.body)
-        if self.headers is not None:
-            msg += '\n%s' % self.headers
-        return msg
+        return '%s: %s %s\n%s' % (self.__class__.__name__,
+                                  self.status, self.reason, self.body)
 
     def __str__(self):
-        msg = '%s: %s %s\n%s' % (self.__class__.__name__,
-                                 self.status, self.reason, self.body)
-        if self.headers is not None:
-            msg += '\n%s' % self.headers
-        return msg
+        return '%s: %s %s\n%s' % (self.__class__.__name__,
+                                  self.status, self.reason, self.body)
 
     def startElement(self, name, attrs, connection):
         pass
@@ -304,9 +295,9 @@ class StorageResponseError(BotoServerError):
     """
     Error in response from a storage service.
     """
-    def __init__(self, status, reason, body=None, *args):
+    def __init__(self, status, reason, body=None, *args, headers=None):
         self.resource = None
-        super(StorageResponseError, self).__init__(status, reason, body, *args)
+        super(StorageResponseError, self).__init__(status, reason, body, *args, headers=headers)
 
     def startElement(self, name, attrs, connection):
         return super(StorageResponseError, self).startElement(

--- a/boto/exception.py
+++ b/boto/exception.py
@@ -89,6 +89,7 @@ class BotoServerError(StandardError):
             self.headers = args[0]
         else:
             self.headers = None
+
         if isinstance(self.body, bytes):
             try:
                 self.body = self.body.decode('utf-8')

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -974,7 +974,7 @@ class Key(object):
             if not self.should_retry(response, False):
                 raise provider.storage_response_error(
                     response.status, response.reason,
-                    body, headers=response.getheaders())
+                    body, response.getheaders())
 
             return response
 

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -843,7 +843,7 @@ class Key(object):
                                                    expires_in_absolute,
                                                    version_id)
 
-    def post_file(self, fp, headers, fields, post_policy):
+    def post_file(self, fp, headers, fields, post_policy, headers_on_error=False):
         provider = self.bucket.connection.provider
         try:
             spos = fp.tell()
@@ -972,8 +972,12 @@ class Key(object):
             body = response.read()
 
             if not self.should_retry(response, False):
-                raise provider.storage_response_error(
-                    response.status, response.reason, body)
+                if headers_on_error:
+                    raise provider.storage_response_error(
+                        response.status, response.getheaders(), body)
+                else:
+                    raise provider.storage_response_error(
+                        response.status, response.reason, body)
 
             return response
 
@@ -2009,7 +2013,7 @@ class Key(object):
     def post_contents_from_file(self, fp, headers=None, post_policy=None,
                                 fields={}, policy=None,
                                 reduced_redundancy=False, encrypt_key=None,
-                                checksum=None):
+                                checksum=None, headers_on_error=False):
         """
         Store an object in S3 using the name of the Key object
         as the key in S3 and the contents of the file pointed to
@@ -2053,6 +2057,12 @@ class Key(object):
         :type checksum: string
         :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
             the checksum for the object.
+
+        :type headers_on_error: bool
+        :param headers_on_error: If True, the "response headers" will be sent
+            back to the client instead of "reason" with the response status
+            and body on error.
+            Otherwise, the response status, reason and body will be sent.
 
         :rtype: int
         :return: The number of bytes written to the key.
@@ -2103,7 +2113,7 @@ class Key(object):
         fp.seek(spos)
 
         self.post_file(fp, headers=headers, fields=fields,
-                       post_policy=post_policy)
+                       post_policy=post_policy, headers_on_error=headers_on_error)
 
         # return number of bytes written.
         return self.size

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -974,7 +974,7 @@ class Key(object):
             if not self.should_retry(response, False):
                 raise provider.storage_response_error(
                     response.status, response.reason,
-                    body, response.getheaders())
+                    body, headers=response.getheaders())
 
             return response
 

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -2121,13 +2121,14 @@ class Key(object):
     def post_contents_from_string(self, string_data, headers=None,
                                   post_policy=None, fields={}, policy=None,
                                   reduced_redundancy=False,
-                                  encrypt_key=None):
+                                  encrypt_key=None, headers_on_error=False):
         if not isinstance(string_data, bytes):
             string_data = string_data.encode("utf-8")
         fp = BytesIO(string_data)
         r = self.post_contents_from_file(fp, headers, post_policy, fields,
                                          policy, reduced_redundancy,
-                                         encrypt_key=encrypt_key)
+                                         encrypt_key=encrypt_key,
+                                         headers_on_error=headers_on_error)
         fp.close()
         return r
 

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -843,7 +843,7 @@ class Key(object):
                                                    expires_in_absolute,
                                                    version_id)
 
-    def post_file(self, fp, headers, fields, post_policy, headers_on_error=False):
+    def post_file(self, fp, headers, fields, post_policy):
         provider = self.bucket.connection.provider
         try:
             spos = fp.tell()
@@ -972,12 +972,9 @@ class Key(object):
             body = response.read()
 
             if not self.should_retry(response, False):
-                if headers_on_error:
-                    raise provider.storage_response_error(
-                        response.status, response.getheaders(), body)
-                else:
-                    raise provider.storage_response_error(
-                        response.status, response.reason, body)
+                raise provider.storage_response_error(
+                    response.status, response.reason,
+                    body, response.getheaders())
 
             return response
 
@@ -2013,7 +2010,7 @@ class Key(object):
     def post_contents_from_file(self, fp, headers=None, post_policy=None,
                                 fields={}, policy=None,
                                 reduced_redundancy=False, encrypt_key=None,
-                                checksum=None, headers_on_error=False):
+                                checksum=None):
         """
         Store an object in S3 using the name of the Key object
         as the key in S3 and the contents of the file pointed to
@@ -2057,12 +2054,6 @@ class Key(object):
         :type checksum: string
         :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
             the checksum for the object.
-
-        :type headers_on_error: bool
-        :param headers_on_error: If True, the "response headers" will be sent
-            back to the client instead of "reason" with the response status
-            and body on error.
-            Otherwise, the response status, reason and body will be sent.
 
         :rtype: int
         :return: The number of bytes written to the key.
@@ -2113,7 +2104,7 @@ class Key(object):
         fp.seek(spos)
 
         self.post_file(fp, headers=headers, fields=fields,
-                       post_policy=post_policy, headers_on_error=headers_on_error)
+                       post_policy=post_policy)
 
         # return number of bytes written.
         return self.size
@@ -2121,14 +2112,13 @@ class Key(object):
     def post_contents_from_string(self, string_data, headers=None,
                                   post_policy=None, fields={}, policy=None,
                                   reduced_redundancy=False,
-                                  encrypt_key=None, headers_on_error=False):
+                                  encrypt_key=None):
         if not isinstance(string_data, bytes):
             string_data = string_data.encode("utf-8")
         fp = BytesIO(string_data)
         r = self.post_contents_from_file(fp, headers, post_policy, fields,
                                          policy, reduced_redundancy,
-                                         encrypt_key=encrypt_key,
-                                         headers_on_error=headers_on_error)
+                                         encrypt_key=encrypt_key)
         fp.close()
         return r
 


### PR DESCRIPTION
QA team needs to check the response headers of POST Object API on error in some automation cases.
Made some changes to response back the response headers on error exception and raise an exception with response.getheaders() on error in post_file() method for POST Object API. 



