### PR TITLE
HS-60348 Add BucketKeyEnabled config for s3:PutBucketEncryption

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -2454,7 +2454,7 @@ class Bucket(object):
             raise self.connection.provider.storage_response_error(
                 response.status, response.reason, body)
 
-    def make_encryption_body(self, ssealgorithm, kmsmasterkeyid=None):
+    def make_encryption_body(self, ssealgorithm, kmsmasterkeyid=None, bucketkeyenabled=False):
         s = '<?xml version="1.0" encoding="UTF-8"?>\n'
         s += '  <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\n'
         s += '    <Rule>\n'
@@ -2463,11 +2463,12 @@ class Bucket(object):
         if kmsmasterkeyid is not None:
             s += '        <KMSMasterKeyID>%s</KMSMasterKeyID>\n' % kmsmasterkeyid
         s += '      </ApplyServerSideEncryptionByDefault>\n'
+        s += '      <BucketKeyEnabled>%s</BucketKeyEnabled>\n' % bucketkeyenabled
         s += '    </Rule>\n'
         s += '  </ServerSideEncryptionConfiguration>\n'
         return s
 
-    def configure_encryption(self, ssealgorithm, kmsmasterkeyid=None, headers=None, checksum=None):
+    def configure_encryption(self, ssealgorithm, kmsmasterkeyid=None, headers=None, checksum=None, bucketkeyenabled=False):
         """
         Configure encryption for this bucket.
 
@@ -2488,7 +2489,7 @@ class Bucket(object):
         """
         provider = self.connection.provider
         headers = headers or {}
-        body = self.make_encryption_body(ssealgorithm, kmsmasterkeyid)
+        body = self.make_encryption_body(ssealgorithm, kmsmasterkeyid, bucketkeyenabled)
         body = body.encode('utf-8')
         headers = set_checksum_header(checksum, provider, headers, data=body)
         response = self.connection.make_request('PUT', self.name, data=body,


### PR DESCRIPTION
Add the ability to set the `BucketKeyEnabled` property for `s3:PutBucketEncryption` requests.  I've tested that `s3:GetBucketEncryption` just reports what's sent back from the server, so already handles the property.