### PR TITLE
HS-60348 Add BucketKeyEnabled config for s3:PutBucketEncryption - 2

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -2454,7 +2454,7 @@ class Bucket(object):
             raise self.connection.provider.storage_response_error(
                 response.status, response.reason, body)
 
-    def make_encryption_body(self, ssealgorithm, kmsmasterkeyid=None, bucketkeyenabled=False):
+    def make_encryption_body(self, ssealgorithm, kmsmasterkeyid=None, bucketkeyenabled=None):
         s = '<?xml version="1.0" encoding="UTF-8"?>\n'
         s += '  <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\n'
         s += '    <Rule>\n'
@@ -2463,12 +2463,13 @@ class Bucket(object):
         if kmsmasterkeyid is not None:
             s += '        <KMSMasterKeyID>%s</KMSMasterKeyID>\n' % kmsmasterkeyid
         s += '      </ApplyServerSideEncryptionByDefault>\n'
-        s += '      <BucketKeyEnabled>%s</BucketKeyEnabled>\n' % bucketkeyenabled
+        if bucketkeyenabled is not None:
+            s += '      <BucketKeyEnabled>%s</BucketKeyEnabled>\n' % bucketkeyenabled
         s += '    </Rule>\n'
         s += '  </ServerSideEncryptionConfiguration>\n'
         return s
 
-    def configure_encryption(self, ssealgorithm, kmsmasterkeyid=None, headers=None, checksum=None, bucketkeyenabled=False):
+    def configure_encryption(self, ssealgorithm, kmsmasterkeyid=None, headers=None, checksum=None, bucketkeyenabled=None):
         """
         Configure encryption for this bucket.
 


### PR DESCRIPTION
The previous fix of toms3/boto for BucketKeyEnabled feature works against Amazon S3 and 8.2.1. However it will not work with 8.2 as 8.2 and earlier do not support BucketKeyEnabled element yet and will return 400 Bad Request as follows.

Change to make a _BucketKeyEnabled element_ in the XML body only if **bucketkeyenabled** parameter is not None.

```
# ./bucket.py -Y -t AES256 -4 r1bn
Using 'cloudian' user '0'

Putting Bucket encryption for: r1bn
Traceback (most recent call last):
  File "./bucket.py", line 562, in <module>
    bucket.configure_encryption(type, Id, headers=headers, checksum=checksum, bucketkeyenabled=bucketkeyenabled)
  File "/root/work/boto/boto/s3/bucket.py", line 2502, in configure_encryption
    response.status, response.reason, body)
boto.exception.S3ResponseError: S3ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?><Error><Code>MalformedXML</Code><Message>The XML you provided was not well-formed or did not validate against our published schema</Message><RequestId>280dd517-dfcf-104a-b663-0242ac1c0002</RequestId><HostId>6091e1e9a4fa4cd58ca1ad8318ddbe60</HostId></Error>
#

####
T 2024/12/11 13:15:21.287919 172.28.0.1:43122 -> 172.28.0.2:80 [AP] #4
PUT /?encryption HTTP/1.1.
Accept-Encoding: identity.
User-Agent: Boto/2.42.0 Python/3.6.8 Linux/3.10.0-862.14.4.el7.x86_64.
x-amz-content-sha256: e82f7643e2632e7b635daa077579feeb56f810acb6b7b61ca6da0935e62db2f1.
X-Amz-Date: 20241211T041521Z.
Authorization: AWS4-HMAC-SHA256 Credential=00f05ce70cc195d0730d/20241211/region1/s3/aws4_request,SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date,Signature=f97b0556ce9fb2f8d64e9d7183b7a2cfe65ae852789a8b673f2dc3399fcc7bb0.
Content-Length: 367.
Host: r1bn.s3-region1.cloudian.com.
.

##
T 2024/12/11 13:15:21.287972 172.28.0.1:43122 -> 172.28.0.2:80 [AP] #6
<?xml version="1.0" encoding="UTF-8"?>
  <ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <Rule>
      <ApplyServerSideEncryptionByDefault>
        <SSEAlgorithm>AES256</SSEAlgorithm>
      </ApplyServerSideEncryptionByDefault>
      <BucketKeyEnabled>False</BucketKeyEnabled>
    </Rule>
  </ServerSideEncryptionConfiguration>

##
T 2024/12/11 13:15:21.291115 172.28.0.2:80 -> 127.0.0.1:43122 [AP] #8
HTTP/1.1 400 Bad Request.
Date: Wed, 11 Dec 2024 04:15:21 GMT.
X-Content-Type-Options: nosniff.
x-amz-request-id: 280dd517-dfcf-104a-b663-0242ac1c0002.
Content-Type: application/xml.
Content-Length: 294.
Server: CloudianS3.
.
<?xml version="1.0" encoding="UTF-8"?><Error><Code>MalformedXML</Code><Message>The XML you provided was not well-formed or did not validate against our published schema</Message><RequestId>280dd517-dfcf-104a-b663-0242ac1c0002</RequestId><HostId>6091e1e9a4fa4cd58ca1ad8318ddbe60</HostId></Error>
####
```