### PR TITLE
Support a new checksum type for "CRC64NVME"

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -79,6 +79,8 @@ CHECKSUM_CRC32_HEADER_KEY = 'checksum-crc32-header'
 CHECKSUM_CRC32C_HEADER_KEY = 'checksum-crc32c-header'
 CHECKSUM_SHA1_HEADER_KEY = 'checksum-sha1-header'
 CHECKSUM_SHA256_HEADER_KEY = 'checksum-sha256-header'
+CHECKSUM_CRC64NVME_HEADER_KEY = 'checksum-crc64nvme-header'
+CHECKSUM_TYPE_HEADER_KEY = 'checksum-type-header'
 CHECKSUM_MODE_HEADER_KEY = 'checksum-mode-header'
 
 STORAGE_COPY_ERROR = 'StorageCopyError'
@@ -170,6 +172,8 @@ class Provider(object):
             CHECKSUM_CRC32C_HEADER_KEY: AWS_HEADER_PREFIX + 'checksum-crc32c',
             CHECKSUM_SHA1_HEADER_KEY: AWS_HEADER_PREFIX + 'checksum-sha1',
             CHECKSUM_SHA256_HEADER_KEY: AWS_HEADER_PREFIX + 'checksum-sha256',
+            CHECKSUM_CRC64NVME_HEADER_KEY: AWS_HEADER_PREFIX + 'checksum-crc64nvme',
+            CHECKSUM_TYPE_HEADER_KEY: AWS_HEADER_PREFIX + 'checksum-type',
             CHECKSUM_MODE_HEADER_KEY: AWS_HEADER_PREFIX + 'checksum-mode',
         },
         'google': {
@@ -209,6 +213,8 @@ class Provider(object):
             CHECKSUM_CRC32C_HEADER_KEY: None,
             CHECKSUM_SHA1_HEADER_KEY: None,
             CHECKSUM_SHA256_HEADER_KEY: None,
+            CHECKSUM_CRC64NVME_HEADER_KEY: None,
+            CHECKSUM_TYPE_HEADER_KEY: None,
             CHECKSUM_MODE_HEADER_KEY: None,
         }
     }
@@ -530,6 +536,8 @@ class Provider(object):
         self.checksum_crc32c_header = header_info_map[CHECKSUM_CRC32C_HEADER_KEY]
         self.checksum_sha1_header = header_info_map[CHECKSUM_SHA1_HEADER_KEY]
         self.checksum_sha256_header = header_info_map[CHECKSUM_SHA256_HEADER_KEY]
+        self.checksum_crc64nvme_header = header_info_map[CHECKSUM_CRC64NVME_HEADER_KEY]
+        self.checksum_type_header = header_info_map[CHECKSUM_TYPE_HEADER_KEY]
         self.checksum_mode_header = header_info_map[CHECKSUM_MODE_HEADER_KEY]
 
     def configure_errors(self):

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -842,8 +842,8 @@ class Bucket(object):
             be set to x-amz-bypass-governance-retention header as value
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         :returns: An instance of MultiDeleteResult
         """
@@ -1060,8 +1060,8 @@ class Bucket(object):
             want to apply to the specified object.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
-            the checksum for the object.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm used
+            to create the checksum for the object.
 
         :type policy: :class:`boto.s3.acl.CannedACLStrings`
         :param policy: A canned ACL policy that will be applied instead
@@ -1104,7 +1104,7 @@ class Bucket(object):
         if object_lock_legal_hold is not None:
             headers[provider.object_lock_legal_hold_header] = object_lock_legal_hold
         if checksum is not None:
-            # "x-amz-checksum-algorithm" header: CRC32|CRC32C|SHA1|SHA256
+            # "x-amz-checksum-algorithm" header: CRC32|CRC32C|CRC64NVME|SHA1|SHA256
             headers[provider.checksum_algorithm_header] = checksum
         response = self.connection.make_request('PUT', self.name, new_key_name,
                                                 headers=headers,
@@ -1437,8 +1437,8 @@ class Bucket(object):
             BucketLogging object.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         :rtype: bool
         :return: True if ok or raises an exception.
@@ -1475,8 +1475,8 @@ class Bucket(object):
             the log files which are created.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         :rtype: bool
         :return: True if ok or raises an exception.
@@ -1493,8 +1493,8 @@ class Bucket(object):
         Disable logging on a bucket.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         :rtype: bool
         :return: True if ok or raises an exception.
@@ -1583,8 +1583,8 @@ class Bucket(object):
             property of the bucket.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         """
         provider = self.connection.provider
@@ -1648,8 +1648,8 @@ class Bucket(object):
             to configure for this bucket.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
         """
         provider = self.connection.provider
         headers = headers or {}
@@ -1723,8 +1723,8 @@ class Bucket(object):
             to configure for this bucket.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
         """
         provider = self.connection.provider
         headers = headers or {}
@@ -2066,8 +2066,8 @@ class Bucket(object):
         :param policy: The JSON policy as a string.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         """
         provider = self.connection.provider
@@ -2188,7 +2188,7 @@ class Bucket(object):
                                   object_lock_mode=None,
                                   object_lock_retain_until_date=None,
                                   object_lock_legal_hold=None,
-                                  checksum=None):
+                                  checksum=None, checksum_type=None):
         """
         Start a multipart upload operation.
 
@@ -2245,8 +2245,13 @@ class Bucket(object):
             want to apply to the specified object.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
-            the checksum for the object.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the object.
+
+        :type checksum_type: string
+        :param checksum: COMPOSITE|FULL_OBJECT. Indicates the checksum type
+            that you want S3 Server to use to calculate the object's checksum
+            value.
         """
         query_args = 'uploads'
         provider = self.connection.provider
@@ -2274,6 +2279,8 @@ class Bucket(object):
             headers[provider.object_lock_legal_hold_header] = object_lock_legal_hold
         if checksum is not None:
             headers[provider.checksum_algorithm_header] = checksum
+        if checksum_type is not None:
+            headers[provider.checksum_type_header] = checksum_type
         response = self.connection.make_request('POST', self.name, key_name,
                                                 query_args=query_args,
                                                 headers=headers)
@@ -2292,6 +2299,7 @@ class Bucket(object):
             k = self.key_class(self)
             k.handle_checksum_headers(response)
             resp.checksum_algorithm = k.checksum_algorithm
+            resp.checksum_type = k.checksum_type
             return resp
         else:
             raise self.connection.provider.storage_response_error(
@@ -2483,8 +2491,8 @@ class Bucket(object):
                                encryption
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
-            create the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         :returns: True if the configuration succeeds or else
                   throws an exception

--- a/boto/s3/checksums.py
+++ b/boto/s3/checksums.py
@@ -16,120 +16,13 @@
 #
 
 import base64
-import array
 import hashlib
-import zlib
 
-CRC32C_TABEL = (
-    0x00000000, 0xf26b8303, 0xe13b70f7, 0x1350f3f4,
-    0xc79a971f, 0x35f1141c, 0x26a1e7e8, 0xd4ca64eb,
-    0x8ad958cf, 0x78b2dbcc, 0x6be22838, 0x9989ab3b,
-    0x4d43cfd0, 0xbf284cd3, 0xac78bf27, 0x5e133c24,
-    0x105ec76f, 0xe235446c, 0xf165b798, 0x030e349b,
-    0xd7c45070, 0x25afd373, 0x36ff2087, 0xc494a384,
-    0x9a879fa0, 0x68ec1ca3, 0x7bbcef57, 0x89d76c54,
-    0x5d1d08bf, 0xaf768bbc, 0xbc267848, 0x4e4dfb4b,
-    0x20bd8ede, 0xd2d60ddd, 0xc186fe29, 0x33ed7d2a,
-    0xe72719c1, 0x154c9ac2, 0x061c6936, 0xf477ea35,
-    0xaa64d611, 0x580f5512, 0x4b5fa6e6, 0xb93425e5,
-    0x6dfe410e, 0x9f95c20d, 0x8cc531f9, 0x7eaeb2fa,
-    0x30e349b1, 0xc288cab2, 0xd1d83946, 0x23b3ba45,
-    0xf779deae, 0x05125dad, 0x1642ae59, 0xe4292d5a,
-    0xba3a117e, 0x4851927d, 0x5b016189, 0xa96ae28a,
-    0x7da08661, 0x8fcb0562, 0x9c9bf696, 0x6ef07595,
-    0x417b1dbc, 0xb3109ebf, 0xa0406d4b, 0x522bee48,
-    0x86e18aa3, 0x748a09a0, 0x67dafa54, 0x95b17957,
-    0xcba24573, 0x39c9c670, 0x2a993584, 0xd8f2b687,
-    0x0c38d26c, 0xfe53516f, 0xed03a29b, 0x1f682198,
-    0x5125dad3, 0xa34e59d0, 0xb01eaa24, 0x42752927,
-    0x96bf4dcc, 0x64d4cecf, 0x77843d3b, 0x85efbe38,
-    0xdbfc821c, 0x2997011f, 0x3ac7f2eb, 0xc8ac71e8,
-    0x1c661503, 0xee0d9600, 0xfd5d65f4, 0x0f36e6f7,
-    0x61c69362, 0x93ad1061, 0x80fde395, 0x72966096,
-    0xa65c047d, 0x5437877e, 0x4767748a, 0xb50cf789,
-    0xeb1fcbad, 0x197448ae, 0x0a24bb5a, 0xf84f3859,
-    0x2c855cb2, 0xdeeedfb1, 0xcdbe2c45, 0x3fd5af46,
-    0x7198540d, 0x83f3d70e, 0x90a324fa, 0x62c8a7f9,
-    0xb602c312, 0x44694011, 0x5739b3e5, 0xa55230e6,
-    0xfb410cc2, 0x092a8fc1, 0x1a7a7c35, 0xe811ff36,
-    0x3cdb9bdd, 0xceb018de, 0xdde0eb2a, 0x2f8b6829,
-    0x82f63b78, 0x709db87b, 0x63cd4b8f, 0x91a6c88c,
-    0x456cac67, 0xb7072f64, 0xa457dc90, 0x563c5f93,
-    0x082f63b7, 0xfa44e0b4, 0xe9141340, 0x1b7f9043,
-    0xcfb5f4a8, 0x3dde77ab, 0x2e8e845f, 0xdce5075c,
-    0x92a8fc17, 0x60c37f14, 0x73938ce0, 0x81f80fe3,
-    0x55326b08, 0xa759e80b, 0xb4091bff, 0x466298fc,
-    0x1871a4d8, 0xea1a27db, 0xf94ad42f, 0x0b21572c,
-    0xdfeb33c7, 0x2d80b0c4, 0x3ed04330, 0xccbbc033,
-    0xa24bb5a6, 0x502036a5, 0x4370c551, 0xb11b4652,
-    0x65d122b9, 0x97baa1ba, 0x84ea524e, 0x7681d14d,
-    0x2892ed69, 0xdaf96e6a, 0xc9a99d9e, 0x3bc21e9d,
-    0xef087a76, 0x1d63f975, 0x0e330a81, 0xfc588982,
-    0xb21572c9, 0x407ef1ca, 0x532e023e, 0xa145813d,
-    0x758fe5d6, 0x87e466d5, 0x94b49521, 0x66df1622,
-    0x38cc2a06, 0xcaa7a905, 0xd9f75af1, 0x2b9cd9f2,
-    0xff56bd19, 0x0d3d3e1a, 0x1e6dcdee, 0xec064eed,
-    0xc38d26c4, 0x31e6a5c7, 0x22b65633, 0xd0ddd530,
-    0x0417b1db, 0xf67c32d8, 0xe52cc12c, 0x1747422f,
-    0x49547e0b, 0xbb3ffd08, 0xa86f0efc, 0x5a048dff,
-    0x8ecee914, 0x7ca56a17, 0x6ff599e3, 0x9d9e1ae0,
-    0xd3d3e1ab, 0x21b862a8, 0x32e8915c, 0xc083125f,
-    0x144976b4, 0xe622f5b7, 0xf5720643, 0x07198540,
-    0x590ab964, 0xab613a67, 0xb831c993, 0x4a5a4a90,
-    0x9e902e7b, 0x6cfbad78, 0x7fab5e8c, 0x8dc0dd8f,
-    0xe330a81a, 0x115b2b19, 0x020bd8ed, 0xf0605bee,
-    0x24aa3f05, 0xd6c1bc06, 0xc5914ff2, 0x37faccf1,
-    0x69e9f0d5, 0x9b8273d6, 0x88d28022, 0x7ab90321,
-    0xae7367ca, 0x5c18e4c9, 0x4f48173d, 0xbd23943e,
-    0xf36e6f75, 0x0105ec76, 0x12551f82, 0xe03e9c81,
-    0x34f4f86a, 0xc69f7b69, 0xd5cf889d, 0x27a40b9e,
-    0x79b737ba, 0x8bdcb4b9, 0x988c474d, 0x6ae7c44e,
-    0xbe2da0a5, 0x4c4623a6, 0x5f16d052, 0xad7d5351,
-    )
-
-CRC32_INIT = 0
-_MASK = 0xFFFFFFFF
-
-def crc32c_update(crc32c, data):
-  """Update CRC-32C checksum with data.
-  Args:
-    crc32c: 32-bit checksum to update as long.
-    data: byte array, string or iterable over bytes.
-  Returns:
-    32-bit updated CRC-32C as long.
-  """
-  if type(data) != array.array or data.itemsize != 1:
-    buf = array.array("B", data)
-  else:
-    buf = data
-  crc32c = crc32c ^ _MASK
-  for b in buf:
-    table_index = (crc32c ^ b) & 0xff
-    crc32c = (CRC32C_TABEL[table_index] ^ (crc32c >> 8)) & _MASK
-  return crc32c ^ _MASK
-
-def crc32c_finalize(crc32c):
-  """Finalize CRC-32C checksum.
-  This function should be called as last step of crc32 calculation.
-  Args:
-    crc32c: 32-bit checksum as long.
-  Returns:
-    finalized 32-bit checksum as long
-  """
-  return crc32c & _MASK
-
-def crc32c_cal(data):
-  """Compute CRC-32C checksum of the data.
-  Args:
-    data: byte array, string or iterable over bytes.
-  Returns:
-    32-bit CRC-32C checksum of data as long.
-  """
-  return crc32c_finalize(crc32c_update(CRC32_INIT, data))
+from awscrt import checksums
 
 # Caller should specify at least 'fp' or 'data'
 # and 'data' is higher priority to use for checksum calculation.
-def cal_checksum(fp=None, size=-1, ctype='crc32', data=None):
+def cal_checksum(fp=None, size=-1, ctype='crc32', data=None, previous_checksum=0):
     checksum = None
     if data is not None:
         rdata = data
@@ -137,11 +30,14 @@ def cal_checksum(fp=None, size=-1, ctype='crc32', data=None):
         cpos = fp.tell()
         rdata = fp.read(size)
     if ctype == 'crc32':
-        checksum = zlib.crc32(rdata, CRC32_INIT) & _MASK
+        checksum = checksums.crc32(rdata, previous_crc32=previous_checksum)
         checksum = base64.b64encode(checksum.to_bytes(4, 'big')).decode('utf-8')
     elif ctype == 'crc32c':
-        checksum = crc32c_cal(rdata)
+        checksum = checksums.crc32c(rdata, previous_crc32c=previous_checksum)
         checksum = base64.b64encode(checksum.to_bytes(4, 'big')).decode('utf-8')
+    elif ctype == 'crc64nvme':
+        checksum = checksums.crc64nvme(rdata, previous_crc64nvme=previous_checksum)
+        checksum = base64.b64encode(checksum.to_bytes(8, 'big')).decode('utf-8')
     elif ctype in ['sha1', 'sha256']:
         if ctype == 'sha1':
             h = hashlib.sha1()
@@ -164,12 +60,12 @@ def set_checksum_header(checksum, provider, headers,
     Add checksum headers to headers dict if it is not
     set yet and checksum is specified.
     Adding headers:
-        x-amz-sdk-checksum-algorithm: CRC32|CRC32C|SHA1|SHA256
-        x-amz-checksum-{crc32|crc32c|sha1|sha256}: calculated
+        x-amz-sdk-checksum-algorithm: CRC32|CRC32C|CRC64NVME|SHA1|SHA256
+        x-amz-checksum-{crc32|crc32c|crc64nvme|sha1|sha256}: calculated
                                                    checksum value
 
     :type checksum: string
-    :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to
+    :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm used to
         create the checksum for the request body.
 
     :type provider: Provider
@@ -192,19 +88,21 @@ def set_checksum_header(checksum, provider, headers,
     headers = headers or {}
     if checksum is None:
         return headers
-    # "x-amz-sdk-checksum-algorithm" header: CRC32|CRC32C|SHA1|SHA256
+    # "x-amz-sdk-checksum-algorithm" header: CRC32|CRC32C|CRC64NVME|SHA1|SHA256
     # If key/value already provided in headers dictionary, we will use it as is.
     if provider.sdk_checksum_algorithm_header not in headers:
         headers[provider.sdk_checksum_algorithm_header] = checksum
     # calculate based on the algorithm
     checksum_lower = checksum.lower()
-    if checksum_lower in ['crc32', 'crc32c', 'sha1', 'sha256']:
+    if checksum_lower in ['crc32', 'crc32c', 'crc64nvme','sha1', 'sha256']:
         calculated_checksum = cal_checksum(fp=fp, size=size, ctype=checksum_lower, data=data)
         # If key/value already provided in headers dictionary, we will use it as is.
         if checksum_lower == 'crc32' and provider.checksum_crc32_header not in headers:
             headers[provider.checksum_crc32_header] = calculated_checksum
         elif checksum_lower == 'crc32c' and provider.checksum_crc32c_header not in headers:
             headers[provider.checksum_crc32c_header] = calculated_checksum
+        elif checksum_lower == 'crc64nvme' and provider.checksum_crc64nvme_header not in headers:
+            headers[provider.checksum_crc64nvme_header] = calculated_checksum
         elif checksum_lower == 'sha1' and provider.checksum_sha1_header not in headers:
             headers[provider.checksum_sha1_header] = calculated_checksum
         elif checksum_lower == 'sha256' and provider.checksum_sha256_header not in headers:

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -172,8 +172,10 @@ class Key(object):
         self.checksum_algorithm = None
         self.checksum_crc32 = None
         self.checksum_crc32c = None
+        self.checksum_crc64nvme = None
         self.checksum_sha1 = None
         self.checksum_sha256 = None
+        self.checksum_type = None
 
     def __repr__(self):
         if self.bucket:
@@ -363,6 +365,12 @@ class Key(object):
                 provider.checksum_crc32c_header, None)
         else:
             self.checksum_crc32c = None
+        # CRC64NVME
+        if provider.checksum_crc64nvme_header:
+            self.checksum_crc64nvme = resp.getheader(
+                provider.checksum_crc64nvme_header, None)
+        else:
+            self.checksum_crc64nvme = None
         # SHA1
         if provider.checksum_sha1_header:
             self.checksum_sha1 = resp.getheader(
@@ -375,6 +383,12 @@ class Key(object):
                 provider.checksum_sha256_header, None)
         else:
             self.checksum_sha256 = None
+        # COMPOSITE|FULL_OBJECT
+        if provider.checksum_type_header:
+            self.checksum_type = resp.getheader(
+                provider.checksum_type_header, None)
+        else:
+            self.checksum_type = None
 
     def handle_bucket_key_enabled_headers(self, resp):
         provider = self.bucket.connection.provider
@@ -667,10 +681,14 @@ class Key(object):
             self.checksum_crc32 = value
         elif name == 'ChecksumCRC32C':
             self.checksum_crc32c = value
+        elif name == 'ChecksumCRC64NVME':
+            self.checksum_crc64nvme = value
         elif name == 'ChecksumSHA1':
             self.checksum_sha1 = value
         elif name == 'ChecksumSHA256':
             self.checksum_sha256 = value
+        elif name == 'ChecksumType':
+            self.checksum_type = value
         else:
             setattr(self, name, value)
 
@@ -1758,8 +1776,8 @@ class Key(object):
             want to apply to the specified object.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
-            the checksum for the object.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm used
+            to create the checksum for the object.
 
         :rtype: int
         :return: The number of bytes written to the key.
@@ -2062,8 +2080,8 @@ class Key(object):
             while at rest in S3.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
-            the checksum for the object.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the object.
 
         :rtype: int
         :return: The number of bytes written to the key.
@@ -2082,13 +2100,13 @@ class Key(object):
             if provider.storage_class_header:
                 fields[provider.storage_class_header] = self.storage_class
         if checksum is not None:
-            # "x-amz-sdk-checksum-algorithm" field: CRC32|CRC32C|SHA1|SHA256
+            # "x-amz-sdk-checksum-algorithm" field: CRC32|CRC32C|CRC64NVME|SHA1|SHA256
             fields[provider.sdk_checksum_algorithm_header] = checksum
             decode_json_data = json.loads(post_policy)
             decode_json_data['conditions'].append(('starts-with', '$%s' % provider.sdk_checksum_algorithm_header, ''))
             # calculate based on the algorithm
             checksum_lower = checksum.lower()
-            if checksum_lower in ['crc32', 'crc32c', 'sha1', 'sha256']:
+            if checksum_lower in ['crc32', 'crc32c', 'crc64nvme', 'sha1', 'sha256']:
                 calculated_checksum = cal_checksum(fp, -1, checksum_lower)
                 if checksum_lower == 'crc32':
                     fields[provider.checksum_crc32_header] = calculated_checksum
@@ -2096,6 +2114,9 @@ class Key(object):
                 elif checksum_lower == 'crc32c':
                     fields[provider.checksum_crc32c_header] = calculated_checksum
                     decode_json_data['conditions'].append(('starts-with', '$%s' % provider.checksum_crc32c_header, ''))
+                elif checksum_lower == 'crc64nvme':
+                    fields[provider.checksum_crc64nvme_header] = calculated_checksum
+                    decode_json_data['conditions'].append(('starts-with', '$%s' % provider.checksum_crc64nvme_header, ''))
                 elif checksum_lower == 'sha1':
                     fields[provider.checksum_sha1_header] = calculated_checksum
                     decode_json_data['conditions'].append(('starts-with', '$%s' % provider.checksum_sha1_header, ''))
@@ -2372,7 +2393,7 @@ class Key(object):
 
         :type checksum_mode: str
         :param checksum_mode: To retrieve the checksum in the response
-            headers of x-amz-checksum-crc32|crc32c|sha1|sha256.
+            headers of x-amz-checksum-crc32|crc32c|crc64nvme|sha1|sha256.
             Valid Values: "ENABLED")
 
         """
@@ -2451,7 +2472,7 @@ class Key(object):
 
         :type checksum_mode: str
         :param checksum_mode: To retrieve the checksum in the response
-            headers of x-amz-checksum-crc32|crc32c|sha1|sha256.
+            headers of x-amz-checksum-crc32|crc32c|crc64nvme|sha1|sha256.
             Valid Values: "ENABLED")
         """
         try:
@@ -2530,7 +2551,7 @@ class Key(object):
 
         :type checksum_mode: str
         :param checksum_mode: To retrieve the checksum in the response
-            headers of x-amz-checksum-crc32|crc32c|sha1|sha256.
+            headers of x-amz-checksum-crc32|crc32c|crc64nvme|sha1|sha256.
             Valid Values: "ENABLED")
 
         :type encoding: str
@@ -2694,8 +2715,8 @@ class Key(object):
             respect to the completion time of the request.
 
         :type checksum: string
-        :param checksum: CRC32|CRC32C|SHA1|SHA256. The algorithm used to create
-            the checksum for the request body.
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm
+            used to create the checksum for the request body.
 
         """
         provider = self.bucket.connection.provider

--- a/boto/s3/multipart.py
+++ b/boto/s3/multipart.py
@@ -52,8 +52,10 @@ class CompleteMultiPartUpload(object):
         self.encrypted = None
         self.checksum_crc32 = None
         self.checksum_crc32c = None
+        self.checksum_crc64nvme = None
         self.checksum_sha1 = None
         self.checksum_sha256 = None
+        self.checksum_type = None
 
     def __repr__(self):
         return '<CompleteMultiPartUpload: %s.%s>' % (self.bucket_name,
@@ -75,10 +77,14 @@ class CompleteMultiPartUpload(object):
             self.checksum_crc32 = value
         elif name == 'ChecksumCRC32C':
             self.checksum_crc32c = value
+        elif name == 'ChecksumCRC64NVME':
+            self.checksum_crc64nvme = value
         elif name == 'ChecksumSHA1':
             self.checksum_sha1 = value
         elif name == 'ChecksumSHA256':
             self.checksum_sha256 = value
+        elif name == 'ChecksumType':
+            self.checksum_type = value
         else:
             setattr(self, name, value)
 
@@ -93,6 +99,7 @@ class Part(object):
      * size - The size, in bytes, of this part
      * checksum_crc32 - The CRC32 checksum value of this part
      * checksum_crc32c - The CRC32C checksum value of this part
+     * checksum_crc64nvme - The CRC64NVME checksum value of this part
      * checksum_sha1 - The SHA1 checksum value of this part
      * checksum_sha256 - The SHA256 checksum value of this part
     """
@@ -105,6 +112,7 @@ class Part(object):
         self.size = None
         self.checksum_crc32 = None
         self.checksum_crc32c = None
+        self.checksum_crc64nvme = None
         self.checksum_sha1 = None
         self.checksum_sha256 = None
 
@@ -130,6 +138,8 @@ class Part(object):
             self.checksum_crc32 = value
         elif name == 'ChecksumCRC32C':
             self.checksum_crc32c = value
+        elif name == 'ChecksumCRC64NVME':
+            self.checksum_crc64nvme = value
         elif name == 'ChecksumSHA1':
             self.checksum_sha1 = value
         elif name == 'ChecksumSHA256':
@@ -171,6 +181,7 @@ class MultiPartUpload(object):
         self.is_truncated = False
         self._parts = None
         self.checksum_algorithm = None
+        self.checksum_type = None
 
     def __repr__(self):
         return '<MultiPartUpload %s>' % self.key_name
@@ -188,6 +199,8 @@ class MultiPartUpload(object):
                 s += '    <ChecksumCRC32>%s</ChecksumCRC32>\n' % part.checksum_crc32
             if part.checksum_crc32c:
                 s += '    <ChecksumCRC32C>%s</ChecksumCRC32C>\n' % part.checksum_crc32c
+            if part.checksum_crc64nvme:
+                s += '    <ChecksumCRC64NVME>%s</ChecksumCRC64NVME>\n' % part.checksum_crc64nvme
             if part.checksum_sha1:
                 s += '    <ChecksumSHA1>%s</ChecksumSHA1>\n' % part.checksum_sha1
             if part.checksum_sha256:
@@ -233,6 +246,8 @@ class MultiPartUpload(object):
             self.initiated = value
         elif name == 'ChecksumAlgorithm':
             self.checksum_algorithm = value
+        elif name == 'ChecksumType':
+            self.checksum_type = value
         else:
             setattr(self, name, value)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ paramiko>=1.10.0
 PyYAML>=3.10
 coverage==3.7.1
 mock==1.0.1
+awscrt >= 0.23.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ paramiko>=1.10.0
 PyYAML>=3.10
 coverage==3.7.1
 mock==1.0.1
-awscrt >= 0.23.8

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2006-2010 Mitch Garnaat http://garnaat.org/
 # Copyright (c) 2010, Eucalyptus Systems, Inc.
@@ -87,6 +87,9 @@ setup(name = "boto",
           "boto.cacerts": ["cacerts.txt"],
           "boto": ["endpoints.json"],
       },
+      install_requires = [
+          "awscrt >= 0.23.8"
+      ],
       license = "MIT",
       platforms = "Posix; MacOS X; Windows",
       classifiers = ["Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
- Support a new checksum algorithm for "`CRC64NVME`" and a checksum type for "`COMPOSITE`|`FULL_OBJECT`"
- Switch to use APIs in awscrt package to compute CRC* checksum algorithm
