### PR TITLE
fix a syntax warning on py38

### DIFF
--- a/boto/iam/connection.py
+++ b/boto/iam/connection.py
@@ -1143,7 +1143,7 @@ class IAMConnection(AWSQueryConnection):
         else:
 
             for tld, policy in DEFAULT_POLICY_DOCUMENTS.items():
-                if tld is 'default':
+                if tld == 'default':
                     # Skip the default. We'll fall back to it if we don't find
                     # anything.
                     continue


### PR DESCRIPTION
py38+ strictly checks Syntax and warns it as follows if it detects.
Fix the warning syntax to have no longer warning.

```
# ./bucket.py
/root/work/boto/boto/iam/connection.py:1146: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if tld is 'default':
Using 'cloudian' user '0'

Owner: 732f7c41a81f0c7b4993d9912a923f95
ContinuationToken: None
#
```