### PR TITLE
Handle either MD5 or Checksum Headers(HS-61701)

### DIFF
--- a/boto/s3/checksums.py
+++ b/boto/s3/checksums.py
@@ -19,6 +19,7 @@ import base64
 import hashlib
 
 from awscrt import checksums
+from boto import config
 
 # Caller should specify at least 'fp' or 'data'
 # and 'data' is higher priority to use for checksum calculation.
@@ -107,4 +108,12 @@ def set_checksum_header(checksum, provider, headers,
             headers[provider.checksum_sha1_header] = calculated_checksum
         elif checksum_lower == 'sha256' and provider.checksum_sha256_header not in headers:
             headers[provider.checksum_sha256_header] = calculated_checksum
+        if config.getbool('Boto', 'either_md5_checksum_headers', True):
+            if len(headers.keys() & {provider.checksum_crc32_header,
+                                     provider.checksum_crc32c_header,
+                                     provider.checksum_crc64nvme_header,
+                                     provider.checksum_sha1_header,
+                                     provider.checksum_sha256_header}) > 0:
+                if 'Content-MD5' in headers:
+                    del headers['Content-MD5']
     return headers

--- a/boto/s3/checksums.py
+++ b/boto/s3/checksums.py
@@ -108,12 +108,17 @@ def set_checksum_header(checksum, provider, headers,
             headers[provider.checksum_sha1_header] = calculated_checksum
         elif checksum_lower == 'sha256' and provider.checksum_sha256_header not in headers:
             headers[provider.checksum_sha256_header] = calculated_checksum
-        if config.getbool('Boto', 'either_md5_checksum_headers', True):
-            if len(headers.keys() & {provider.checksum_crc32_header,
-                                     provider.checksum_crc32c_header,
-                                     provider.checksum_crc64nvme_header,
-                                     provider.checksum_sha1_header,
-                                     provider.checksum_sha256_header}) > 0:
+        # /etc/boto.cfg or ~/.boto file
+        # always_send_md5: True/False(Default: False)
+        #                  True : always send Content-MD5 header
+        #                  False: not send Content-MD5 header if checksum header exists
+        if not config.getbool('Boto', 'always_send_md5', False):
+            checksum_headers = {provider.checksum_crc32_header,
+                                provider.checksum_crc32c_header,
+                                provider.checksum_crc64nvme_header,
+                                provider.checksum_sha1_header,
+                                provider.checksum_sha256_header}
+            if len(set(headers.keys()).intersection(checksum_headers)) > 0:
                 if 'Content-MD5' in headers:
                     del headers['Content-MD5']
     return headers

--- a/boto/s3/key.py
+++ b/boto/s3/key.py
@@ -1136,7 +1136,8 @@ class Key(object):
         return (top, bottom)
 
     def send_file(self, fp, headers=None, cb=None, num_cb=10,
-                  query_args=None, chunked_transfer=False, size=None):
+                  query_args=None, chunked_transfer=False, size=None,
+                  checksum=None):
         """
         Upload a file to a key into a bucket on S3.
 
@@ -1176,14 +1177,20 @@ class Key(object):
             up into different ranges to be uploaded. If not specified,
             the default behaviour is to read all bytes from the file
             pointer. Less bytes may be available.
+
+        :type checksum: string
+        :param checksum: CRC32|CRC32C|CRC64NVME|SHA1|SHA256. The algorithm used
+            to create the checksum for the object.
+
         """
         self._send_file_internal(fp, headers=headers, cb=cb, num_cb=num_cb,
                                  query_args=query_args,
-                                 chunked_transfer=chunked_transfer, size=size)
+                                 chunked_transfer=chunked_transfer, size=size,
+                                 checksum=checksum)
 
     def _send_file_internal(self, fp, headers=None, cb=None, num_cb=10,
                             query_args=None, chunked_transfer=False, size=None,
-                            hash_algs=None):
+                            hash_algs=None, checksum=None):
         provider = self.bucket.connection.provider
         try:
             spos = fp.tell()
@@ -1499,6 +1506,7 @@ class Key(object):
 
         headers['Expect'] = '100-Continue'
         headers = boto.utils.merge_meta(headers, self.metadata, provider)
+        headers = set_checksum_header(checksum, provider, headers, fp=fp, size=size)
         resp = self.bucket.connection.make_request(
             'PUT',
             self.bucket.name,
@@ -1794,8 +1802,6 @@ class Key(object):
             headers[provider.object_lock_retain_until_date_header] = object_lock_retain_until_date
         if object_lock_legal_hold is not None:
             headers[provider.object_lock_legal_hold_header] = object_lock_legal_hold
-        csize = size or -1
-        headers = set_checksum_header(checksum, provider, headers, fp=fp, size=csize)
         if rewind:
             # caller requests reading from beginning of fp.
             fp.seek(0, os.SEEK_SET)
@@ -1893,7 +1899,8 @@ class Key(object):
 
             self.send_file(fp, headers=headers, cb=cb, num_cb=num_cb,
                            query_args=query_args,
-                           chunked_transfer=chunked_transfer, size=size)
+                           chunked_transfer=chunked_transfer, size=size,
+                           checksum=checksum)
             # return number of bytes written.
             return self.size
 


### PR DESCRIPTION
Handle either MD5 or Checksum Headers(HS-61701)

- Add a new bool parameter for `always_send_md5` to be able to turn on/off to this new behavior(Default: False)
  * If you want to disable this behavior(e.g. test against HS8.1.1), you can configure `/etc/boto.cfg` or `~/.boto` file like this
```
[Boto]
always_send_md5 = True
``` 