### PR TITLE
installation with python 3.12

### DIFF
--- a/boto/plugin.py
+++ b/boto/plugin.py
@@ -37,7 +37,12 @@ The actual interface is duck typed.
 """
 
 import glob
-import imp
+import sys
+PY312 = sys.version_info[0:2] >= (3, 12)
+if PY312:
+    import importlib as imp
+else:
+    import imp
 import os.path
 
 

--- a/boto/pyami/launch_ami.py
+++ b/boto/pyami/launch_ami.py
@@ -22,7 +22,11 @@
 #
 import getopt
 import sys
-import imp
+PY312 = sys.version_info[0:2] >= (3, 12)
+if PY312:
+    import importlib as imp
+else:
+    import imp
 import time
 import boto
 

--- a/boto/vendored/six.py
+++ b/boto/vendored/six.py
@@ -71,6 +71,10 @@ else:
             MAXSIZE = int((1 << 63) - 1)
         del X
 
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
 
 def _add_doc(func, doc):
     """Add documentation to a function."""
@@ -184,6 +188,11 @@ class _SixMetaPathImporter(object):
     def find_module(self, fullname, path=None):
         if fullname in self.known_modules:
             return self
+        return None
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
         return None
 
     def __get_module(self, fullname):


### PR DESCRIPTION
Prior to Python3.12, the installation boto using the following pip command works but it fails with Python3.12 for some reason.
Two things have done in this PR.
- Similar issue already reported [here](https://github.com/boto/boto/issues/3951) and made the same [fix](https://github.com/benjaminp/six/pull/352) in our boto
- `imp` is deprecated and is turned into `importlib` in Python 3.12.

**_After the fix_**
```
[root@cld0 toms3]# python3
Python 3.12.8 (main, Dec 12 2024, 16:30:29) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
[root@cld0 toms3]# python3 -m pip install -r requirements.txt
Collecting git+https://github.com/cloudian/boto.git@py12 (from -r requirements.txt (line 2))
  Cloning https://github.com/cloudian/boto.git (to revision py12) to /tmp/pip-req-build-ui2bhp1q
  Running command git clone --filter=blob:none --quiet https://github.com/cloudian/boto.git /tmp/pip-req-build-ui2bhp1q
  Running command git checkout -b py12 --track origin/py12
  Switched to a new branch 'py12'
  branch 'py12' set up to track 'origin/py12'.
  Resolved https://github.com/cloudian/boto.git to commit 17c6bddd95a90b65ce6f0ea57f6930ca0ae4147e
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting awscrt>=0.23.8 (from boto==2.42.0->-r requirements.txt (line 2))
  Obtaining dependency information for awscrt>=0.23.8 from https://files.pythonhosted.org/packages/4c/92/922bf0be0e32517340201dac8879f2ef368fb940c3066847c040fd92f040/awscrt-0.23.9-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
  Downloading awscrt-0.23.9-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.3 kB)
Downloading awscrt-0.23.9-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.7 MB)
   qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq 8.7/8.7 MB 45.0 MB/s eta 0:00:00
Building wheels for collected packages: boto
  Building wheel for boto (pyproject.toml) ... done
  Created wheel for boto: filename=boto-2.42.0-py2.py3-none-any.whl size=1386107 sha256=013cf7e5ad778862baac63bfd254111bc9bc201601bfc48ff19529a82c454a55
  Stored in directory: /tmp/pip-ephem-wheel-cache-4hwy1rv0/wheels/97/12/41/dc26b533462a465c3b49a48a08c418cae2ea062325cdd9ec77
Successfully built boto
Installing collected packages: awscrt, boto
Successfully installed awscrt-0.23.9 boto-2.42.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
[root@cld0 toms3]#
```