### PR TITLE
Correct handling the passed 'headers' param  in complete_multipart_upload method()

### DIFF
--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -2671,8 +2671,7 @@ class Bucket(object):
         Complete a multipart upload operation.
         """
         query_args = 'uploadId=%s' % upload_id
-        if headers is None:
-            headers = {}
+        headers = headers or {}
         headers['Content-Type'] = 'text/xml'
         response = self.connection.make_request('POST', self.name, key_name,
                                                 query_args=query_args,


### PR DESCRIPTION
mpu.py -c(complete) with `-H` option does not work due to this bug.
Fix to handle the passed 'headers' param  in complete_multipart_upload method().