### PR TITLE
Fix proxy connection handling and ensure proper encoding

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -857,9 +857,12 @@ class AWSAuthConnection(object):
         else:
             # Fallback for old Python without ssl.wrap_socket
             if hasattr(http_client, 'ssl'):
+
                 ctx = ssl.create_default_context()
-                ctx.check_hostname = False
-                ctx.verify_mode = ssl.CERT_NONE
+
+                if self.https_validate_certificates is False :
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
                 sslSock = ctx.wrap_socket(sock, server_hostname=host)
                 conn = http_client.HTTPSConnection(host, port, context=ctx)
                 conn.sock = sslSock

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -760,7 +760,7 @@ class AWSAuthConnection(object):
                 'establishing HTTPS connection: host=%s, kwargs=%s',
                 host, http_connection_kwargs)
             if self.use_proxy and not self.skip_proxy(host):
-                connection = self.proxy_ssl(host, is_secure and 443 or 80)
+                connection = self.proxy_ssl(host, port)
             elif self.https_connection_factory:
                 connection = self.https_connection_factory(host)
             elif self.https_validate_certificates and HAVE_HTTPS_CONNECTION:
@@ -809,18 +809,18 @@ class AWSAuthConnection(object):
         else:
             sock = socket.create_connection((self.proxy, int(self.proxy_port)))
         boto.log.debug("Proxy connection: CONNECT %s HTTP/1.0\r\n", host)
-        sock.sendall("CONNECT %s HTTP/1.0\r\n" % host)
-        sock.sendall("User-Agent: %s\r\n" % UserAgent)
+        sock.sendall(("CONNECT %s HTTP/1.0\r\n" % host).encode())
+        sock.sendall(("User-Agent: %s\r\n" % UserAgent).encode())
         if self.proxy_user and self.proxy_pass:
             for k, v in self.get_proxy_auth_header().items():
-                sock.sendall("%s: %s\r\n" % (k, v))
+                sock.sendall(("%s: %s\r\n" % (k, v)).encode())
             # See discussion about this config option at
             # https://groups.google.com/forum/?fromgroups#!topic/boto-dev/teenFvOq2Cc
             if config.getbool('Boto', 'send_crlf_after_proxy_auth_headers', False):
-                sock.sendall("\r\n")
+                sock.sendall("\r\n".encode())
         else:
-            sock.sendall("\r\n")
-        resp = http_client.HTTPResponse(sock, strict=True, debuglevel=self.debug)
+            sock.sendall("\r\n".encode())
+        resp = http_client.HTTPResponse(sock,  debuglevel=self.debug)
         resp.begin()
 
         if resp.status != 200:
@@ -857,7 +857,13 @@ class AWSAuthConnection(object):
         else:
             # Fallback for old Python without ssl.wrap_socket
             if hasattr(http_client, 'ssl'):
-                sslSock = http_client.ssl.SSLSocket(sock)
+                ctx = ssl.create_default_context()
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+                sslSock = ctx.wrap_socket(sock, server_hostname=host)
+                conn = http_client.HTTPSConnection(host, port, context=ctx)
+                conn.sock = sslSock
+                return conn
             else:
                 sslSock = socket.ssl(sock, None, None)
                 sslSock = http_client.FakeSocket(sock, sslSock)

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -860,7 +860,7 @@ class AWSAuthConnection(object):
 
                 ctx = ssl.create_default_context()
 
-                if self.https_validate_certificates is False :
+                if not self.https_validate_certificates:
                     ctx.check_hostname = False
                     ctx.verify_mode = ssl.CERT_NONE
                 sslSock = ctx.wrap_socket(sock, server_hostname=host)


### PR DESCRIPTION
While working on aws-proxy , found python3 and boto( in connection.py: proxy_ssl() ) incompatibility.
This part of the code is only called if ~/.boto config file has proxy settings and HTTPS is being used.
