### PR TITLE
Improve S3 connection handling by conditionally adding port

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -879,8 +879,9 @@ class AWSAuthConnection(object):
         if host is None:
             host = self.server_name()
         else:
-            # Include port if it's non-standard
-            if self.port != PORTS_BY_SECURITY[self.is_secure]:
+            # S3 connection adds the ":" by default.
+            # Only add port if host doesn't already contain it and port is non-standard
+            if ':' not in host and self.port != PORTS_BY_SECURITY[self.is_secure]:
                 host = '%s:%d' % (host, self.port)
         path = self.protocol + '://' + host + path
 


### PR DESCRIPTION
Add logic to add the port only if the `host` does not have the port .
Seems IAM connections does not have the port but S3 does have the port info.

Now both iam and s3 work from toms3.
./iam -L 
./put.py a
./get.py a