### PR TITLE
fix the token_cache handling for Get Session Token API

### DIFF
--- a/boto/sts/connection.py
+++ b/boto/sts/connection.py
@@ -180,7 +180,8 @@ class STSConnection(AWSQueryConnection):
                 token = self._get_session_token(duration,
                                                 mfa_serial_number,
                                                 mfa_token)
-                _session_token_cache[token_key] = token
+                if isinstance(token, Credentials):
+                    _session_token_cache[token_key] = token
             finally:
                 self._mutex.release()
         return token


### PR DESCRIPTION
When calling the Get Session Token API using the persist connection, we can sometimes see the following exception.
`_get_session_token()` can return not only `Credentials` instance but also `BotoServerError` instance in some cases(400 Bad Request etc). In that case, there is no `expiration` attribute and will get an AttributeError below.
The fix is to add the token to the cache only when its  a `Credentials` instance.

```
  File "/root/work/boto/boto/sts/connection.py", line 184, in get_session_token
    token = self._check_token_cache(token_key, duration)
  File "/root/work/boto/boto/sts/connection.py", line 127, in _check_token_cache
    expires = boto.utils.parse_ts(token.expiration)
  File "/root/work/boto/boto/exception.py", line 146, in __getattr__
    raise AttributeError
AttributeError
```